### PR TITLE
Serialisation rework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.1.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <groupId>de.rub.nds</groupId>
     <artifactId>ModifiableVariable</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
     
     <name>ModifiableVariable</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
     <groupId>de.rub.nds</groupId>
     <artifactId>ModifiableVariable</artifactId>
     <version>3.0.0</version>

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -156,6 +156,9 @@ public abstract class ModifiableVariable<E> implements Serializable {
     }
 
     public Boolean isCreateRandomModification() {
+        if (createRandomModification == null) {
+            return false;
+        }
         return createRandomModification;
     }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -8,30 +8,100 @@
  */
 package de.rub.nds.modifiablevariable;
 
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerAddModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerExplicitValueModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerInteractiveModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftLeftModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftRightModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerSubtractModification;
+import de.rub.nds.modifiablevariable.biginteger.BigIntegerXorModification;
+import de.rub.nds.modifiablevariable.bool.BooleanExplicitValueModification;
+import de.rub.nds.modifiablevariable.bool.BooleanToggleModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayDeleteModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayDuplicateModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayExplicitValueModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayInsertModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayPayloadModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayShuffleModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayXorModification;
+import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
+import de.rub.nds.modifiablevariable.integer.IntegerExplicitValueModification;
+import de.rub.nds.modifiablevariable.integer.IntegerShiftLeftModification;
+import de.rub.nds.modifiablevariable.integer.IntegerShiftRightModification;
+import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
+import de.rub.nds.modifiablevariable.integer.IntegerXorModification;
+import de.rub.nds.modifiablevariable.mlong.LongAddModification;
+import de.rub.nds.modifiablevariable.mlong.LongExplicitValueModification;
+import de.rub.nds.modifiablevariable.mlong.LongSubtractModification;
+import de.rub.nds.modifiablevariable.mlong.LongXorModification;
+import de.rub.nds.modifiablevariable.singlebyte.ByteAddModification;
+import de.rub.nds.modifiablevariable.singlebyte.ByteExplicitValueModification;
+import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
+import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
+import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
+import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 import java.io.Serializable;
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlAttribute;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * The base abstract class for modifiable variables, including the getValue
- * function.
- *
- * The class needs to be defined transient to allow propOrder definition in
- * subclasses, see:
+ * function.The class needs to be defined transient to allow propOrder
+ * definition in subclasses, see:
  * http://blog.bdoughan.com/2011/06/ignoring-inheritance-with-xmltransient.html
  *
+ *
+ * @param <E>
  */
 @XmlRootElement
 @XmlTransient
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlJavaTypeAdapter(value = ByteArrayAdapter.class, type = byte[].class)
 public abstract class ModifiableVariable<E> implements Serializable {
 
     protected Boolean autoformat = null;
 
+    @XmlElements(value = {
+            @XmlElement(type = BigIntegerXorModification.class, name = "BigIntegerXorModification"),
+            @XmlElement(type = BigIntegerSubtractModification.class, name = "BigIntegerSubtractModification"),
+            @XmlElement(type = BigIntegerShiftRightModification.class, name = "BigIntegerShiftRightModification"),
+            @XmlElement(type = BigIntegerShiftLeftModification.class, name = "BigIntegerShiftLeftModification"),
+            @XmlElement(type = BigIntegerExplicitValueModification.class, name = "BigIntegerExplicitValueModification"),
+            @XmlElement(type = BigIntegerAddModification.class, name = "BigIntegerAddModification"),
+            @XmlElement(type = BigIntegerInteractiveModification.class, name = "BigIntegerInteractiveModification"),
+            @XmlElement(type = BooleanToggleModification.class, name = "BooleanToggleModification"),
+            @XmlElement(type = BooleanExplicitValueModification.class, name = "BooleanExplicitValueModification"),
+            @XmlElement(type = ByteArrayXorModification.class, name = "ByteArrayXorModification"),
+            @XmlElement(type = ByteArrayShuffleModification.class, name = "ByteArrayShuffleModification"),
+            @XmlElement(type = ByteArrayPayloadModification.class, name = "ByteArrayPayloadModification"),
+            @XmlElement(type = ByteArrayInsertModification.class, name = "ByteArrayInsertModification"),
+            @XmlElement(type = ByteArrayExplicitValueModification.class, name = "ByteArrayExplicitValueModification"),
+            @XmlElement(type = ByteArrayDuplicateModification.class, name = "ByteArrayDuplicateModification"),
+            @XmlElement(type = ByteArrayDeleteModification.class, name = "ByteArrayDeleteModification"),
+            @XmlElement(type = IntegerXorModification.class, name = "IntegerXorModification"),
+            @XmlElement(type = IntegerSubtractModification.class, name = "IntegerSubtractModification"),
+            @XmlElement(type = IntegerShiftRightModification.class, name = "IntegerShiftRightModification"),
+            @XmlElement(type = IntegerShiftLeftModification.class, name = "IntegerShiftLeftModification"),
+            @XmlElement(type = IntegerExplicitValueModification.class, name = "IntegerExplicitValueModification"),
+            @XmlElement(type = IntegerAddModification.class, name = "IntegerAddModification"),
+            @XmlElement(type = LongXorModification.class, name = "LongXorModification"),
+            @XmlElement(type = LongSubtractModification.class, name = "LongSubtractModification"),
+            @XmlElement(type = LongExplicitValueModification.class, name = "LongExplicitValueModification"),
+            @XmlElement(type = LongAddModification.class, name = "LongAddModification"),
+            @XmlElement(type = ByteXorModification.class, name = "ByteXorModification"),
+            @XmlElement(type = ByteSubtractModification.class, name = "ByteSubtractModification"),
+            @XmlElement(type = ByteAddModification.class, name = "ByteAddModification"),
+            @XmlElement(type = ByteExplicitValueModification.class, name = "ByteExplicitValueModification"),
+            @XmlElement(type = StringExplicitValueModification.class, name = "StringExplicitValueModification") })
     private VariableModification<E> modification = null;
 
-    private boolean createRandomModification;
+    private Boolean createRandomModification;
 
     protected E assertEquals;
 
@@ -39,7 +109,6 @@ public abstract class ModifiableVariable<E> implements Serializable {
 
     }
 
-    @XmlAttribute(required = false)
     public Boolean getAutoformat() {
         return autoformat;
     }
@@ -52,13 +121,12 @@ public abstract class ModifiableVariable<E> implements Serializable {
         this.modification = modification;
     }
 
-    @XmlAnyElement(lax = true)
     public VariableModification<E> getModification() {
         return modification;
     }
 
     public E getValue() {
-        if (createRandomModification) {
+        if (Objects.equals(createRandomModification, Boolean.TRUE)) {
             createRandomModification();
             createRandomModification = false;
         }
@@ -87,7 +155,7 @@ public abstract class ModifiableVariable<E> implements Serializable {
         return (assertEquals != null);
     }
 
-    public boolean isCreateRandomModification() {
+    public Boolean isCreateRandomModification() {
         return createRandomModification;
     }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
@@ -8,90 +8,37 @@
  */
 package de.rub.nds.modifiablevariable;
 
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerAddModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerExplicitValueModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerInteractiveModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftLeftModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftRightModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerSubtractModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerXorModification;
-import de.rub.nds.modifiablevariable.bool.BooleanExplicitValueModification;
-import de.rub.nds.modifiablevariable.bool.BooleanToggleModification;
-import de.rub.nds.modifiablevariable.bytearray.*;
 import de.rub.nds.modifiablevariable.filter.AccessModificationFilter;
-import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
-import de.rub.nds.modifiablevariable.integer.IntegerExplicitValueModification;
-import de.rub.nds.modifiablevariable.integer.IntegerShiftLeftModification;
-import de.rub.nds.modifiablevariable.integer.IntegerShiftRightModification;
-import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
-import de.rub.nds.modifiablevariable.integer.IntegerXorModification;
-import de.rub.nds.modifiablevariable.singlebyte.ByteAddModification;
-import de.rub.nds.modifiablevariable.singlebyte.ByteExplicitValueModification;
-import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
-import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
-import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
-import javax.xml.bind.annotation.XmlAnyElement;
+import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @XmlRootElement
 @XmlTransient
-@XmlSeeAlso({ AccessModificationFilter.class, BigIntegerAddModification.class, BigIntegerInteractiveModification.class,
-        BigIntegerExplicitValueModification.class, BigIntegerSubtractModification.class,
-        BooleanExplicitValueModification.class, BooleanToggleModification.class, BigIntegerXorModification.class,
-        BigIntegerShiftLeftModification.class, BigIntegerShiftRightModification.class, IntegerAddModification.class,
-        IntegerExplicitValueModification.class, IntegerSubtractModification.class, IntegerXorModification.class,
-        IntegerShiftLeftModification.class, IntegerShiftRightModification.class, ByteArrayDeleteModification.class,
-        ByteArrayExplicitValueModification.class, ByteArrayInsertModification.class, ByteArrayXorModification.class,
-        ByteArrayDuplicateModification.class, ByteArrayShuffleModification.class, ByteArrayPayloadModification.class,
-        ByteAddModification.class, ByteExplicitValueModification.class, ByteSubtractModification.class,
-        ByteXorModification.class, StringExplicitValueModification.class })
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlJavaTypeAdapter(value = ByteArrayAdapter.class, type = byte[].class)
 public abstract class VariableModification<E> {
 
     protected static final Logger LOGGER = LogManager.getLogger(VariableModification.class);
-
-    /**
-     * post modification for next modification executed on the given variable
-     */
-    private VariableModification<E> postModification = null;
 
     /**
      * In specific cases it is possible to filter out some modifications based
      * on given rules. ModificationFilter is responsible for validating if the
      * modification can be executed.
      */
+    @XmlElements(value = { @XmlElement(type = AccessModificationFilter.class, name = "AccessModificationFilter") })
     private ModificationFilter modificationFilter = null;
-
-    /**
-     * Get the value of postModification
-     *
-     * @return the value of postModification
-     */
-    // http://stackoverflow.com/questions/5122296/jaxb-not-unmarshalling-xml-any-element-to-jaxbelement
-    @XmlAnyElement(lax = true)
-    public VariableModification<E> getPostModification() {
-        return postModification;
-    }
-
-    /**
-     * Set the value of postModification
-     *
-     * @param postModification
-     *            new value of postModification
-     */
-    public void setPostModification(VariableModification<E> postModification) {
-        this.postModification = postModification;
-    }
 
     public E modify(E input) {
         E modifiedValue = modifyImplementationHook(input);
-        if (postModification != null) {
-            modifiedValue = postModification.modify(modifiedValue);
-        }
         if ((modificationFilter == null) || (modificationFilter.filterModification() == false)) {
             debug(modifiedValue);
             return modifiedValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerAddModification.java
@@ -12,11 +12,14 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "summand", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "summand", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerAddModification extends VariableModification<BigInteger> {
 
     private final static int MAX_ADD_LENGTH = 8;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModification.java
@@ -12,11 +12,14 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerExplicitValueModification extends VariableModification<BigInteger> {
 
     private final static int MAX_EXPLICIT_LENGTH = 8;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerInteractiveModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerInteractiveModification.java
@@ -10,13 +10,18 @@ package de.rub.nds.modifiablevariable.biginteger;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "modificationFilter", "postModification" })
+@XmlType(propOrder = { "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerInteractiveModification extends VariableModification<BigInteger> {
 
+    @XmlTransient
     private InteractiveBigIntegerModification modification;
 
     protected BigIntegerInteractiveModification() {

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftLeftModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftLeftModification.java
@@ -11,11 +11,14 @@ package de.rub.nds.modifiablevariable.biginteger;
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "shift", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "shift", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerShiftLeftModification extends VariableModification<BigInteger> {
 
     private final static int MAX_SHIFT_LENGTH = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftRightModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftRightModification.java
@@ -11,11 +11,14 @@ package de.rub.nds.modifiablevariable.biginteger;
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "shift", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "shift", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerShiftRightModification extends VariableModification<BigInteger> {
 
     private final static int MAX_SHIFT_LENGTH = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModification.java
@@ -12,11 +12,14 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "subtrahend", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerSubtractModification extends VariableModification<BigInteger> {
 
     private final static int MAX_SUBTRACT_LENGTH = 8;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModification.java
@@ -12,11 +12,14 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "xor", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "xor", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class BigIntegerXorModification extends VariableModification<BigInteger> {
 
     private final static int MAX_XOR_LENGTH = 8;

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigInteger.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigInteger.java
@@ -13,14 +13,12 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import java.io.Serializable;
 import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ BigIntegerAddModification.class, BigIntegerExplicitValueModification.class,
-        BigIntegerSubtractModification.class, BigIntegerXorModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableBigInteger extends ModifiableVariable<BigInteger> implements Serializable {
 
     private BigInteger originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModification.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
 public class BooleanExplicitValueModification extends VariableModification<Boolean> {
 
     private boolean explicitValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "modificationFilter", "postModification" })
+@XmlType(propOrder = { "modificationFilter" })
 public class BooleanToggleModification extends VariableModification<Boolean> {
 
     public BooleanToggleModification() {

--- a/src/main/java/de/rub/nds/modifiablevariable/bool/ModifiableBoolean.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/ModifiableBoolean.java
@@ -10,13 +10,12 @@ package de.rub.nds.modifiablevariable.bool;
 
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ BooleanExplicitValueModification.class, BooleanExplicitValueModification.class })
-@XmlType(propOrder = { "originalValue", "modification", })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableBoolean extends ModifiableVariable<Boolean> {
 
     private Boolean originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModification.java
@@ -13,11 +13,14 @@ import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import static de.rub.nds.modifiablevariable.util.ArrayConverter.bytesToHexString;
 import java.util.Arrays;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "count", "startPosition", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "count", "startPosition", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayDeleteModification extends VariableModification<byte[]> {
 
     private final static int MAX_MODIFIER_LENGTH = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
@@ -10,11 +10,14 @@ package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "modificationFilter", "postModification" })
+@XmlType(propOrder = { "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayDuplicateModification extends VariableModification<byte[]> {
 
     public ByteArrayDuplicateModification() {

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModification.java
@@ -10,15 +10,16 @@ package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
-import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 import java.util.Arrays;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayExplicitValueModification extends VariableModification<byte[]> {
 
     private final static int MAX_EXPLICIT_VALUE = 256;
@@ -38,7 +39,6 @@ public class ByteArrayExplicitValueModification extends VariableModification<byt
         return explicitValue.clone();
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getExplicitValue() {
         return explicitValue;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertModification.java
@@ -10,15 +10,16 @@ package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
-import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 import java.util.Arrays;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
-@XmlType(propOrder = { "bytesToInsert", "startPosition", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "bytesToInsert", "startPosition", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayInsertModification extends VariableModification<byte[]> {
 
     private final static int MAX_EXPLICIT_VALUE = 256;
@@ -65,7 +66,6 @@ public class ByteArrayInsertModification extends VariableModification<byte[]> {
         return ArrayConverter.concatenate(ret1, bytesToInsert, ret3);
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getBytesToInsert() {
         return bytesToInsert;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPayloadModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPayloadModification.java
@@ -13,14 +13,15 @@ import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 
 import java.util.Arrays;
-import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
-@XmlType(propOrder = { "prependPayload", "payload", "appendPayload", "insert", "insertPosition", "modificationFilter",
-        "postModification" })
+@XmlType(propOrder = { "prependPayload", "payload", "appendPayload", "insert", "insertPosition", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayPayloadModification extends VariableModification<byte[]> {
 
     private byte[] prependPayload = new byte[] {};
@@ -59,7 +60,6 @@ public class ByteArrayPayloadModification extends VariableModification<byte[]> {
         return insertMod.modify(input);
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getPrependPayload() {
         return prependPayload;
     }
@@ -68,7 +68,6 @@ public class ByteArrayPayloadModification extends VariableModification<byte[]> {
         this.prependPayload = prependPayload;
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getPayload() {
         return payload;
     }
@@ -77,7 +76,6 @@ public class ByteArrayPayloadModification extends VariableModification<byte[]> {
         this.payload = payload;
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getAppendPayload() {
         return appendPayload;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayShuffleModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayShuffleModification.java
@@ -13,6 +13,8 @@ import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 import java.util.Arrays;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -24,7 +26,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *
  */
 @XmlRootElement
-@XmlType(propOrder = { "shuffle", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "shuffle", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayShuffleModification extends VariableModification<byte[]> {
 
     private final static int MAX_MODIFIER_VALUE = 256;
@@ -58,7 +61,6 @@ public class ByteArrayShuffleModification extends VariableModification<byte[]> {
         return result;
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getShuffle() {
         return shuffle;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModification.java
@@ -10,15 +10,16 @@ package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
-import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
 import java.util.Arrays;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
-@XmlType(propOrder = { "xor", "startPosition", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "xor", "startPosition", "modificationFilter" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteArrayXorModification extends VariableModification<byte[]> {
 
     private final static int MAX_MODIFIER_VALUE = 256;
@@ -64,7 +65,6 @@ public class ByteArrayXorModification extends VariableModification<byte[]> {
         return result;
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getXor() {
         return xor;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArray.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArray.java
@@ -12,24 +12,23 @@ import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import de.rub.nds.modifiablevariable.util.ByteArrayAdapter;
+import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import java.io.Serializable;
 import java.util.Arrays;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
-@XmlSeeAlso({ ByteArrayDeleteModification.class, ByteArrayExplicitValueModification.class,
-        ByteArrayInsertModification.class, ByteArrayXorModification.class, ByteArrayDuplicateModification.class,
-        ByteArrayPayloadModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableByteArray extends ModifiableVariable<byte[]> implements Serializable {
 
     public ModifiableByteArray() {
         autoformat = true;
     }
 
+    @XmlJavaTypeAdapter(UnformattedByteArrayAdapter.class)
     private byte[] originalValue;
 
     @Override
@@ -38,7 +37,6 @@ public class ModifiableByteArray extends ModifiableVariable<byte[]> implements S
         setModification(vm);
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     @Override
     public byte[] getOriginalValue() {
         return originalValue;
@@ -49,7 +47,6 @@ public class ModifiableByteArray extends ModifiableVariable<byte[]> implements S
         this.originalValue = originalValue;
     }
 
-    @XmlJavaTypeAdapter(ByteArrayAdapter.class)
     public byte[] getAssertEquals() {
         return assertEquals;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/filter/AccessModificationFilter.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/filter/AccessModificationFilter.java
@@ -9,6 +9,8 @@
 package de.rub.nds.modifiablevariable.filter;
 
 import de.rub.nds.modifiablevariable.ModificationFilter;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -20,6 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * 
  */
 @XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
 public class AccessModificationFilter extends ModificationFilter {
 
     private int accessCounter;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerAddModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "summand", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "summand", "modificationFilter" })
 public class IntegerAddModification extends VariableModification<Integer> {
 
     private final static int MAX_ADD_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerExplicitValueModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
 public class IntegerExplicitValueModification extends VariableModification<Integer> {
 
     private final static int MAX_VALUE_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerShiftLeftModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerShiftLeftModification.java
@@ -14,7 +14,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "shift", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "shift", "modificationFilter" })
 public class IntegerShiftLeftModification extends VariableModification<Integer> {
 
     private final static int MAX_SHIFT_MODIFIER = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerShiftRightModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerShiftRightModification.java
@@ -14,7 +14,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "shift", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "shift", "modificationFilter" })
 public class IntegerShiftRightModification extends VariableModification<Integer> {
 
     private final static int MAX_SHIFT_MODIFIER = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerSubtractModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "subtrahend", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
 public class IntegerSubtractModification extends VariableModification<Integer> {
 
     private final static int MAX_SUBTRACT_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerXorModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "xor", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "xor", "modificationFilter" })
 public class IntegerXorModification extends VariableModification<Integer> {
 
     private final static int MAX_VALUE_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/ModifiableInteger.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/ModifiableInteger.java
@@ -12,14 +12,12 @@ import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ IntegerAddModification.class, IntegerExplicitValueModification.class, IntegerSubtractModification.class,
-        IntegerXorModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableInteger extends ModifiableVariable<Integer> implements Serializable {
 
     private Integer originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/length/ModifiableLengthField.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/length/ModifiableLengthField.java
@@ -10,18 +10,12 @@ package de.rub.nds.modifiablevariable.length;
 
 import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
-import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
-import de.rub.nds.modifiablevariable.integer.IntegerExplicitValueModification;
-import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
-import de.rub.nds.modifiablevariable.integer.IntegerXorModification;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ IntegerAddModification.class, IntegerExplicitValueModification.class, IntegerSubtractModification.class,
-        IntegerXorModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableLengthField extends ModifiableInteger {
 
     private final ModifiableByteArray ref;

--- a/src/main/java/de/rub/nds/modifiablevariable/mlong/LongAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/mlong/LongAddModification.java
@@ -9,14 +9,13 @@
 package de.rub.nds.modifiablevariable.mlong;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
 import java.util.Objects;
 import java.util.Random;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "summand", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "summand", "modificationFilter" })
 public class LongAddModification extends VariableModification<Long> {
 
     private final static int MAX_ADD_MODIFIER = 32;

--- a/src/main/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
 public class LongExplicitValueModification extends VariableModification<Long> {
 
     private final static int MAX_EXPLICIT_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/mlong/LongSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/mlong/LongSubtractModification.java
@@ -9,14 +9,13 @@
 package de.rub.nds.modifiablevariable.mlong;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
 import java.util.Objects;
 import java.util.Random;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "subtrahend", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
 public class LongSubtractModification extends VariableModification<Long> {
 
     private final static int MAX_SUBTRACT_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/mlong/LongXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/mlong/LongXorModification.java
@@ -9,14 +9,13 @@
 package de.rub.nds.modifiablevariable.mlong;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
 import java.util.Objects;
 import java.util.Random;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "xor", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "xor", "modificationFilter" })
 public class LongXorModification extends VariableModification<Long> {
 
     private final static int MAX_XOR_MODIFIER = 256;

--- a/src/main/java/de/rub/nds/modifiablevariable/mlong/ModifiableLong.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/mlong/ModifiableLong.java
@@ -12,14 +12,12 @@ import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ LongAddModification.class, LongExplicitValueModification.class, LongSubtractModification.class,
-        LongXorModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableLong extends ModifiableVariable<Long> implements Serializable {
 
     private Long originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteAddModification.java
@@ -9,14 +9,13 @@
 package de.rub.nds.modifiablevariable.singlebyte;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
 import java.util.Objects;
 import java.util.Random;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "summand", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "summand", "modificationFilter" })
 public class ByteAddModification extends VariableModification<Byte> {
 
     private final static int MAX_ADD_MODIFIER = 16;

--- a/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteExplicitValueModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
 public class ByteExplicitValueModification extends VariableModification<Byte> {
 
     private final static int MAX_EXPLICIT_MODIFIER = 16;

--- a/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteSubtractModification.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "subtrahend", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
 public class ByteSubtractModification extends VariableModification<Byte> {
 
     private final static int MAX_SUBTRACT_MODIFIER = 16;

--- a/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ByteXorModification.java
@@ -11,11 +11,13 @@ package de.rub.nds.modifiablevariable.singlebyte;
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.util.Objects;
 import java.util.Random;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlType(propOrder = { "xor", "modificationFilter", "postModification" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ByteXorModification extends VariableModification<Byte> {
 
     private final static int MAX_XOR_MODIFIER = 16;

--- a/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ModifiableByte.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/singlebyte/ModifiableByte.java
@@ -11,14 +11,12 @@ package de.rub.nds.modifiablevariable.singlebyte;
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
-@XmlSeeAlso({ ByteAddModification.class, ByteExplicitValueModification.class, ByteSubtractModification.class,
-        ByteXorModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableByte extends ModifiableVariable<Byte> implements Serializable {
 
     private Byte originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/string/ModifiableString.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/ModifiableString.java
@@ -18,16 +18,15 @@ package de.rub.nds.modifiablevariable.string;
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 /**
  *
  */
 @XmlRootElement
-@XmlSeeAlso({ StringExplicitValueModification.class })
-@XmlType(propOrder = { "originalValue", "modification", "assertEquals" })
+@XmlAccessorType(XmlAccessType.FIELD)
 public class ModifiableString extends ModifiableVariable<String> implements Serializable {
 
     private String originalValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringExplicitValueModification.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  *
  */
 @XmlRootElement
-@XmlType(propOrder = { "explicitValue", "modificationFilter", "postModification" })
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
 public class StringExplicitValueModification extends VariableModification<String> {
 
     private String explicitValue;

--- a/src/main/java/de/rub/nds/modifiablevariable/util/XMLPrettyPrinter.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/XMLPrettyPrinter.java
@@ -25,7 +25,6 @@ import javax.xml.xpath.*;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerOperationConcartenationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerOperationConcartenationTest.java
@@ -30,17 +30,6 @@ public class BigIntegerOperationConcartenationTest {
     }
 
     @Test
-    public void testAddThenMultiply() {
-        // (input + 4) ^ 3 = (10 + 4) ^ 3 = 13
-        VariableModification<BigInteger> modifier = BigIntegerModificationFactory.add("4");
-        start.setModification(modifier);
-        modifier.setPostModification(BigIntegerModificationFactory.xor("3"));
-        expectedResult = new BigInteger("13");
-        result = start.getValue();
-        assertEquals(expectedResult, result);
-    }
-
-    @Test
     public void testAddThenMultiplyWithInnerClass() {
         // (input + 4) ^ 3 = (10 + 4) ^ 3 = 13
         start.setModification(new VariableModification<BigInteger>() {

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayOperationConcartenationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayOperationConcartenationTest.java
@@ -8,10 +8,7 @@
  */
 package de.rub.nds.modifiablevariable.bytearray;
 
-import de.rub.nds.modifiablevariable.VariableModification;
 import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class ByteArrayOperationConcartenationTest {
 
@@ -26,16 +23,5 @@ public class ByteArrayOperationConcartenationTest {
     public void setUp() {
         start = new ModifiableByteArray();
         start.setOriginalValue(new byte[] { 1, 10 });
-    }
-
-    @Test
-    public void testInsertThenXOR() {
-        // input (insert4@1) xor 1,2,3 = 1 4 10 XOR 1 2 3,
-        VariableModification<byte[]> modifier = ByteArrayModificationFactory.insert(new byte[] { 4 }, 1);
-        start.setModification(modifier);
-        modifier.setPostModification(ByteArrayModificationFactory.xor(new byte[] { 1, 2, 3 }, 0));
-        expectedResult = new byte[] { 0, 6, 9 };
-        result = start.getValue();
-        assertArrayEquals(expectedResult, result);
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/BigIntegerSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/BigIntegerSerializationTest.java
@@ -89,10 +89,8 @@ public class BigIntegerSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModification() throws Exception {
+    public void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<BigInteger> modifier = BigIntegerModificationFactory.add(BigInteger.ONE);
-        VariableModification<BigInteger> modifier2 = BigIntegerModificationFactory.add(BigInteger.ONE);
-        modifier.setPostModification(modifier2);
         start.setModification(modifier);
         m.marshal(start, writer);
 
@@ -102,7 +100,7 @@ public class BigIntegerSerializationTest {
         um = context.createUnmarshaller();
         ModifiableBigInteger mv = (ModifiableBigInteger) um.unmarshal(new StringReader(xmlString));
 
-        expectedResult = new BigInteger("12");
+        expectedResult = new BigInteger("11");
         result = mv.getValue();
         assertEquals(expectedResult, result);
         assertNotSame(expectedResult, result);
@@ -127,13 +125,11 @@ public class BigIntegerSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModificationFilter() throws Exception {
+    public void testSerializeDeserializeWithModificationFilter() throws Exception {
         VariableModification<BigInteger> modifier = BigIntegerModificationFactory.add(BigInteger.ONE);
         int[] filtered = { 1, 3 };
         AccessModificationFilter filter = ModificationFilterFactory.access(filtered);
         modifier.setModificationFilter(filter);
-        VariableModification<BigInteger> modifier2 = BigIntegerModificationFactory.add(BigInteger.ONE);
-        modifier.setPostModification(modifier2);
         start.setModification(modifier);
         m.marshal(start, writer);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteArraySerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteArraySerializationTest.java
@@ -83,10 +83,9 @@ public class ByteArraySerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModification() throws Exception {
+    public void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<byte[]> modifier = ByteArrayModificationFactory.insert(new byte[] { 1, 2 }, 0);
-        VariableModification<byte[]> modifier2 = ByteArrayModificationFactory.insert(new byte[] { 9, 8, 7 }, 3);
-        modifier.setPostModification(modifier2);
+
         start.setModification(modifier);
         m.marshal(start, writer);
 
@@ -96,7 +95,7 @@ public class ByteArraySerializationTest {
         um = context.createUnmarshaller();
         ModifiableByteArray mba = (ModifiableByteArray) um.unmarshal(new StringReader(xmlString));
 
-        expectedResult = new byte[] { 1, 2, (byte) 0xff, 9, 8, 7, 1, 2, 3 };
+        expectedResult = new byte[] { 1, 2, (byte) 0xff, 1, 2, 3 };
         result = mba.getValue();
         assertArrayEquals(expectedResult, result);
         assertNotSame(expectedResult, result);
@@ -104,13 +103,11 @@ public class ByteArraySerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModificationFilter() throws Exception {
+    public void testSerializeDeserializeWithModificationFilter() throws Exception {
         VariableModification<byte[]> modifier = ByteArrayModificationFactory.delete(1, 1);
         int[] filtered = { 1, 3 };
         AccessModificationFilter filter = ModificationFilterFactory.access(filtered);
         modifier.setModificationFilter(filter);
-        VariableModification<byte[]> modifier2 = ByteArrayModificationFactory.xor(new byte[] { 1 }, 1);
-        modifier.setPostModification(modifier2);
         start.setModification(modifier);
         m.marshal(start, writer);
 
@@ -120,19 +117,10 @@ public class ByteArraySerializationTest {
         um = context.createUnmarshaller();
         ModifiableByteArray mv = (ModifiableByteArray) um.unmarshal(new StringReader(xmlString));
 
-        // it happens nothing, because the first modification is filtered
+        // it happens nothing, because the modification is filtered
         expectedResult = new byte[] { (byte) 0xff, 1, 2, 3 };
         result = mv.getValue();
         assertArrayEquals(expectedResult, result);
         assertNotSame(expectedResult, result);
-
-        // there we have a modification
-        // first, 1 is deleted
-        // then, 2 is xored with 1, resulting in 3
-        expectedResult = new byte[] { (byte) 0xff, 3, 3 };
-        result = mv.getValue();
-        assertArrayEquals(expectedResult, result);
-        assertNotSame(expectedResult, result);
-
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/LongSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/LongSerializationTest.java
@@ -79,10 +79,8 @@ public class LongSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModification() throws Exception {
+    public void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<Long> modifier = LongModificationFactory.add(1L);
-        VariableModification<Long> modifier2 = LongModificationFactory.add(1L);
-        modifier.setPostModification(modifier2);
         start.setModification(modifier);
         m.marshal(start, writer);
 
@@ -92,20 +90,18 @@ public class LongSerializationTest {
         um = context.createUnmarshaller();
         ModifiableLong mv = (ModifiableLong) um.unmarshal(new StringReader(xmlString));
 
-        expectedResult = 12L;
+        expectedResult = 11L;
         result = mv.getValue();
         assertEquals(expectedResult, result);
 
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModificationFilter() throws Exception {
+    public void testSerializeDeserializeWithModificationFilter() throws Exception {
         VariableModification<Long> modifier = LongModificationFactory.add(1L);
         int[] filtered = { 1, 3 };
         AccessModificationFilter filter = ModificationFilterFactory.access(filtered);
         modifier.setModificationFilter(filter);
-        VariableModification<Long> modifier2 = LongModificationFactory.add(1L);
-        modifier.setPostModification(modifier2);
         start.setModification(modifier);
         m.marshal(start, writer);
 


### PR DESCRIPTION
Reworked the way modifiable variables are serialized by changing some jaxb declarations. This allows us to use XSD in other projects which use this project. This PR also removed the ability to apply post modifactions which have to be added in a future release