### PR TITLE
fix: Allow ModifiableVariable project as submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
+                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
                     <violationSeverity>info</violationSeverity>
                     <failOnViolation>false</failOnViolation>
                 </configuration>
@@ -126,7 +126,7 @@
                 <artifactId>formatter-maven-plugin</artifactId>
                 <version>2.14.0</version>
                 <configuration>
-                    <configFile>maven-eclipse-codestyle.xml</configFile>
+                    <configFile>${project.basedir}/maven-eclipse-codestyle.xml</configFile>
                 </configuration>
                 <executions>
                     <execution>
@@ -141,7 +141,7 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <header>license_header_plain.txt</header>
+                    <header>${project.basedir}/license_header_plain.txt</header>
                     <strictCheck>true</strictCheck>
                     <includes>
                         <include>src/**/*.java</include>


### PR DESCRIPTION
This PR is similar to https://github.com/tls-attacker/TLS-Attacker-Development/pull/894 and enables ModifiableVariable to be used as a submodule in other projects. For more details refer to the PR made to TLS-Attacker.