### PR TITLE
Add Support for Unsigned Datatypes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <version>2.6</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -24,6 +24,10 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
 import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
 import de.rub.nds.modifiablevariable.uinteger.*;
+import de.rub.nds.modifiablevariable.ulong.UnsignedLongAddModification;
+import de.rub.nds.modifiablevariable.ulong.UnsignedLongExplicitValueModification;
+import de.rub.nds.modifiablevariable.ulong.UnsignedLongSubtractModification;
+import de.rub.nds.modifiablevariable.ulong.UnsignedLongXorModification;
 
 import javax.xml.bind.annotation.*;
 import java.io.Serializable;
@@ -76,6 +80,10 @@ public abstract class ModifiableVariable<E> implements Serializable {
         @XmlElement(type = LongSubtractModification.class, name = "LongSubtractModification"),
         @XmlElement(type = LongExplicitValueModification.class, name = "LongExplicitValueModification"),
         @XmlElement(type = LongAddModification.class, name = "LongAddModification"),
+        @XmlElement(type = UnsignedLongAddModification.class, name = "UnsignedLongAddModification"),
+        @XmlElement(type = UnsignedLongSubtractModification.class, name = "UnsignedLongSubtractModification"),
+        @XmlElement(type = UnsignedLongXorModification.class, name = "UnsignedLongXorModification"),
+        @XmlElement(type = UnsignedLongExplicitValueModification.class, name = "UnsignedLongExplicitValueModification"),
         @XmlElement(type = ByteXorModification.class, name = "ByteXorModification"),
         @XmlElement(type = ByteSubtractModification.class, name = "ByteSubtractModification"),
         @XmlElement(type = ByteAddModification.class, name = "ByteAddModification"),

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -9,29 +9,11 @@
 
 package de.rub.nds.modifiablevariable;
 
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerAddModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerExplicitValueModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerInteractiveModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerMultiplyModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftLeftModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerShiftRightModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerSubtractModification;
-import de.rub.nds.modifiablevariable.biginteger.BigIntegerXorModification;
+import de.rub.nds.modifiablevariable.biginteger.*;
 import de.rub.nds.modifiablevariable.bool.BooleanExplicitValueModification;
 import de.rub.nds.modifiablevariable.bool.BooleanToggleModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayDeleteModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayDuplicateModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayExplicitValueModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayInsertModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayPayloadModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayShuffleModification;
-import de.rub.nds.modifiablevariable.bytearray.ByteArrayXorModification;
-import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
-import de.rub.nds.modifiablevariable.integer.IntegerExplicitValueModification;
-import de.rub.nds.modifiablevariable.integer.IntegerShiftLeftModification;
-import de.rub.nds.modifiablevariable.integer.IntegerShiftRightModification;
-import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
-import de.rub.nds.modifiablevariable.integer.IntegerXorModification;
+import de.rub.nds.modifiablevariable.bytearray.*;
+import de.rub.nds.modifiablevariable.integer.*;
 import de.rub.nds.modifiablevariable.mlong.LongAddModification;
 import de.rub.nds.modifiablevariable.mlong.LongExplicitValueModification;
 import de.rub.nds.modifiablevariable.mlong.LongSubtractModification;
@@ -41,16 +23,11 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteExplicitValueModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
 import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
-import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
+import de.rub.nds.modifiablevariable.uinteger.*;
+
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * The base abstract class for modifiable variables, including the getValue function.The class needs to be defined
@@ -88,6 +65,13 @@ public abstract class ModifiableVariable<E> implements Serializable {
         @XmlElement(type = IntegerShiftLeftModification.class, name = "IntegerShiftLeftModification"),
         @XmlElement(type = IntegerExplicitValueModification.class, name = "IntegerExplicitValueModification"),
         @XmlElement(type = IntegerAddModification.class, name = "IntegerAddModification"),
+        @XmlElement(type = UnsignedIntegerAddModification.class, name = "UnsignedIntegerAddModification"),
+        @XmlElement(type = UnsignedIntegerSubtractModification.class, name = "UnsignedIntegerSubtractModification"),
+        @XmlElement(type = UnsignedIntegerXorModification.class, name = "UnsignedIntegerXorModification"),
+        @XmlElement(type = UnsignedIntegerExplicitValueModification.class,
+            name = "UnsignedIntegerExplicitValueModification"),
+        @XmlElement(type = UnsignedIntegerShiftLeftModification.class, name = "UnsignedIntegerShiftLeftModification"),
+        @XmlElement(type = UnsignedIntegerShiftRightModification.class, name = "UnsignedIntegerShiftRightModification"),
         @XmlElement(type = LongXorModification.class, name = "LongXorModification"),
         @XmlElement(type = LongSubtractModification.class, name = "LongSubtractModification"),
         @XmlElement(type = LongExplicitValueModification.class, name = "LongExplicitValueModification"),

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableFactory.java
@@ -10,6 +10,7 @@
 package de.rub.nds.modifiablevariable;
 
 import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import de.rub.nds.modifiablevariable.biginteger.ModifiableBigInteger;
 import de.rub.nds.modifiablevariable.bool.ModifiableBoolean;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
@@ -18,6 +19,7 @@ import de.rub.nds.modifiablevariable.mlong.ModifiableLong;
 import de.rub.nds.modifiablevariable.singlebyte.ModifiableByte;
 import de.rub.nds.modifiablevariable.string.ModifiableString;
 import de.rub.nds.modifiablevariable.uinteger.ModifiableUnsignedInteger;
+import de.rub.nds.modifiablevariable.ulong.ModifiableUnsignedLong;
 
 import java.math.BigInteger;
 
@@ -45,6 +47,10 @@ public class ModifiableVariableFactory {
 
     public static ModifiableLong createLongModifiableVariable() {
         return new ModifiableLong();
+    }
+
+    public static ModifiableUnsignedLong createUnsignedLongModifiableVariable() {
+        return new ModifiableUnsignedLong();
     }
 
     public static ModifiableBigInteger safelySetValue(ModifiableBigInteger mv, BigInteger value) {
@@ -106,6 +112,22 @@ public class ModifiableVariableFactory {
     public static ModifiableLong safelySetValue(ModifiableLong mv, Long value) {
         if (mv == null) {
             mv = new ModifiableLong();
+        }
+        mv.setOriginalValue(value);
+        return mv;
+    }
+
+    public static ModifiableUnsignedLong safelySetValue(ModifiableUnsignedLong mv, Long value) {
+        if (mv == null) {
+            mv = new ModifiableUnsignedLong();
+        }
+        mv.setOriginalValue(value);
+        return mv;
+    }
+
+    public static ModifiableUnsignedLong safelySetValue(ModifiableUnsignedLong mv, UnsignedLong value) {
+        if (mv == null) {
+            mv = new ModifiableUnsignedLong();
         }
         mv.setOriginalValue(value);
         return mv;

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableFactory.java
@@ -9,6 +9,7 @@
 
 package de.rub.nds.modifiablevariable;
 
+import com.google.common.primitives.UnsignedInteger;
 import de.rub.nds.modifiablevariable.biginteger.ModifiableBigInteger;
 import de.rub.nds.modifiablevariable.bool.ModifiableBoolean;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
@@ -16,6 +17,8 @@ import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import de.rub.nds.modifiablevariable.mlong.ModifiableLong;
 import de.rub.nds.modifiablevariable.singlebyte.ModifiableByte;
 import de.rub.nds.modifiablevariable.string.ModifiableString;
+import de.rub.nds.modifiablevariable.uinteger.ModifiableUnsignedInteger;
+
 import java.math.BigInteger;
 
 public class ModifiableVariableFactory {
@@ -26,6 +29,10 @@ public class ModifiableVariableFactory {
 
     public static ModifiableInteger createIntegerModifiableVariable() {
         return new ModifiableInteger();
+    }
+
+    public static ModifiableUnsignedInteger createUnsignedIntegerModifiableVariable() {
+        return new ModifiableUnsignedInteger();
     }
 
     public static ModifiableByte createByteModifiableVariable() {
@@ -59,6 +66,22 @@ public class ModifiableVariableFactory {
     public static ModifiableInteger safelySetValue(ModifiableInteger mv, Integer value) {
         if (mv == null) {
             mv = new ModifiableInteger();
+        }
+        mv.setOriginalValue(value);
+        return mv;
+    }
+
+    public static ModifiableUnsignedInteger safelySetValue(ModifiableUnsignedInteger mv, Integer value) {
+        if (mv == null) {
+            mv = new ModifiableUnsignedInteger();
+        }
+        mv.setOriginalValue(value);
+        return mv;
+    }
+
+    public static ModifiableUnsignedInteger safelySetValue(ModifiableUnsignedInteger mv, UnsignedInteger value) {
+        if (mv == null) {
+            mv = new ModifiableUnsignedInteger();
         }
         mv.setOriginalValue(value);
         return mv;

--- a/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
@@ -38,7 +38,7 @@ public abstract class VariableModification<E> {
 
     public E modify(E input) {
         E modifiedValue = modifyImplementationHook(input);
-        if ((modificationFilter == null) || (modificationFilter.filterModification() == false)) {
+        if (modificationFilter == null || !modificationFilter.filterModification()) {
             debug(modifiedValue);
             return modifiedValue;
         } else {

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/ModifiableUnsignedInteger.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/ModifiableUnsignedInteger.java
@@ -1,0 +1,89 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.ModifiableVariable;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ModifiableUnsignedInteger extends ModifiableVariable<UnsignedInteger> {
+
+    private UnsignedInteger originalValue;
+
+    @Override
+    protected void createRandomModification() {
+        VariableModification<UnsignedInteger> vm = UnsignedIntegerModificationFactory.createRandomModification();
+        setModification(vm);
+    }
+
+    public UnsignedInteger getAssertEquals() {
+        return assertEquals;
+    }
+
+    public void setAssertEquals(UnsignedInteger assertEquals) {
+        this.assertEquals = assertEquals;
+    }
+
+    @Override
+    public boolean isOriginalValueModified() {
+        return getOriginalValue() != null && getOriginalValue().compareTo(getValue()) != 0;
+    }
+
+    @Override
+    public boolean validateAssertions() {
+        return assertEquals == null || assertEquals.compareTo(getValue()) == 0;
+    }
+
+    @Override
+    public UnsignedInteger getOriginalValue() {
+        return originalValue;
+    }
+
+    @Override
+    public void setOriginalValue(UnsignedInteger originalValue) {
+        this.originalValue = originalValue;
+    }
+
+    public void setOriginalValue(Integer originalValue) {
+        this.originalValue = originalValue != null ? UnsignedInteger.fromIntBits(originalValue) : null;
+    }
+
+    @Override
+    public String toString() {
+        return "ModifiableUnsignedInteger{originalValue=" + originalValue + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ModifiableUnsignedInteger)) {
+            return false;
+        }
+
+        ModifiableUnsignedInteger that = (ModifiableUnsignedInteger) o;
+
+        return getValue() != null ? getValue().equals(that.getValue()) : that.getValue() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (getValue() != null ? getValue().hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerAddModification.java
@@ -1,0 +1,83 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "summand", "modificationFilter" })
+public class UnsignedIntegerAddModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_ADD_MODIFIER = 256;
+
+    private UnsignedInteger summand;
+
+    public UnsignedIntegerAddModification() {
+
+    }
+
+    public UnsignedIntegerAddModification(Integer bi) {
+        this(bi != null ? UnsignedInteger.fromIntBits(bi) : null);
+    }
+
+    public UnsignedIntegerAddModification(UnsignedInteger bi) {
+        this.summand = bi;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(UnsignedInteger input) {
+        return (input == null) ? summand : input.plus(summand);
+    }
+
+    public UnsignedInteger getSummand() {
+        return summand;
+    }
+
+    public void setSummand(UnsignedInteger summand) {
+        this.summand = summand;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        UnsignedInteger modification = UnsignedInteger.fromIntBits(new Random().nextInt(MAX_ADD_MODIFIER));
+        return new UnsignedIntegerAddModification(summand.plus(modification));
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 23 * hash + Objects.hashCode(this.summand);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerAddModification other = (UnsignedIntegerAddModification) obj;
+        if (!Objects.equals(this.summand, other.summand)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerAddModification.java
@@ -46,6 +46,10 @@ public class UnsignedIntegerAddModification extends VariableModification<Unsigne
         return summand;
     }
 
+    public void setSummand(Integer summand) {
+        setSummand(summand != null ? UnsignedInteger.fromIntBits(summand) : null);
+    }
+
     public void setSummand(UnsignedInteger summand) {
         this.summand = summand;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerExplicitValueModification.java
@@ -1,0 +1,88 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
+public class UnsignedIntegerExplicitValueModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_VALUE_MODIFIER = 256;
+
+    private UnsignedInteger explicitValue;
+
+    public UnsignedIntegerExplicitValueModification() {
+
+    }
+
+    public UnsignedIntegerExplicitValueModification(Integer bi) {
+        this(bi != null ? UnsignedInteger.fromIntBits(bi) : null);
+    }
+
+    public UnsignedIntegerExplicitValueModification(UnsignedInteger bi) {
+        this.explicitValue = bi;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(final UnsignedInteger input) {
+        return explicitValue;
+    }
+
+    public UnsignedInteger getExplicitValue() {
+        return explicitValue;
+    }
+
+    public void setExplicitValue(UnsignedInteger explicitValue) {
+        this.explicitValue = explicitValue;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        Random r = new Random();
+        UnsignedInteger modification = UnsignedInteger.fromIntBits(r.nextInt(MAX_VALUE_MODIFIER));
+        if (r.nextBoolean() || explicitValue.compareTo(modification) < 0) {
+            return new UnsignedIntegerExplicitValueModification(explicitValue.plus(modification));
+        } else {
+            return new UnsignedIntegerExplicitValueModification(explicitValue.minus(modification));
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 53 * hash + Objects.hashCode(this.explicitValue);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerExplicitValueModification other = (UnsignedIntegerExplicitValueModification) obj;
+        if (!Objects.equals(this.explicitValue, other.explicitValue)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerExplicitValueModification.java
@@ -54,7 +54,7 @@ public class UnsignedIntegerExplicitValueModification extends VariableModificati
     public VariableModification<UnsignedInteger> getModifiedCopy() {
         Random r = new Random();
         UnsignedInteger modification = UnsignedInteger.fromIntBits(r.nextInt(MAX_VALUE_MODIFIER));
-        if (r.nextBoolean() || explicitValue.compareTo(modification) < 0) {
+        if (r.nextBoolean()) {
             return new UnsignedIntegerExplicitValueModification(explicitValue.plus(modification));
         } else {
             return new UnsignedIntegerExplicitValueModification(explicitValue.minus(modification));

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerModificationFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerModificationFactory.java
@@ -1,0 +1,115 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+import de.rub.nds.modifiablevariable.util.RandomHelper;
+
+import java.util.Random;
+
+public class UnsignedIntegerModificationFactory {
+
+    private static final int MODIFICATION_COUNT = 6;
+
+    private static final int MAX_MODIFICATION_VALUE = 32000;
+
+    private static final int MAX_MODIFICATION_SHIFT_VALUE = 20;
+
+    public static UnsignedIntegerAddModification add(final String summand) {
+        return new UnsignedIntegerAddModification(UnsignedInteger.valueOf(summand));
+    }
+
+    public static UnsignedIntegerAddModification add(final Integer summand) {
+        return new UnsignedIntegerAddModification(summand);
+    }
+
+    public static UnsignedIntegerAddModification add(final UnsignedInteger summand) {
+        return new UnsignedIntegerAddModification(summand);
+    }
+
+    public static UnsignedIntegerSubtractModification sub(final String subtrahend) {
+        return new UnsignedIntegerSubtractModification(UnsignedInteger.valueOf(subtrahend));
+    }
+
+    public static UnsignedIntegerSubtractModification sub(final Integer subtrahend) {
+        return new UnsignedIntegerSubtractModification(subtrahend);
+    }
+
+    public static UnsignedIntegerSubtractModification sub(final UnsignedInteger subtrahend) {
+        return new UnsignedIntegerSubtractModification(subtrahend);
+    }
+
+    public static UnsignedIntegerXorModification xor(final String xor) {
+        return new UnsignedIntegerXorModification(UnsignedInteger.valueOf(xor));
+    }
+
+    public static UnsignedIntegerXorModification xor(final Integer xor) {
+        return new UnsignedIntegerXorModification(xor);
+    }
+
+    public static UnsignedIntegerXorModification xor(final UnsignedInteger xor) {
+        return new UnsignedIntegerXorModification(xor);
+    }
+
+    public static UnsignedIntegerExplicitValueModification explicitValue(final String value) {
+        return new UnsignedIntegerExplicitValueModification(UnsignedInteger.valueOf(value));
+    }
+
+    public static UnsignedIntegerExplicitValueModification explicitValue(final Integer value) {
+        return new UnsignedIntegerExplicitValueModification(value);
+    }
+
+    public static UnsignedIntegerExplicitValueModification explicitValue(final UnsignedInteger value) {
+        return new UnsignedIntegerExplicitValueModification(value);
+    }
+
+    public static UnsignedIntegerShiftLeftModification shiftLeft(final String shift) {
+        return new UnsignedIntegerShiftLeftModification(Integer.parseInt(shift));
+    }
+
+    public static UnsignedIntegerShiftLeftModification shiftLeft(final Integer shift) {
+        return new UnsignedIntegerShiftLeftModification(shift);
+    }
+
+    public static UnsignedIntegerShiftRightModification shiftRight(final String shift) {
+        return new UnsignedIntegerShiftRightModification(Integer.parseInt(shift));
+    }
+
+    public static UnsignedIntegerShiftRightModification shiftRight(final Integer shift) {
+        return new UnsignedIntegerShiftRightModification(shift);
+    }
+
+    public static VariableModification<UnsignedInteger> createRandomModification() {
+        Random random = RandomHelper.getRandom();
+        int r = random.nextInt(MODIFICATION_COUNT);
+        int modification = random.nextInt(MAX_MODIFICATION_VALUE);
+        int shiftModification = random.nextInt(MAX_MODIFICATION_SHIFT_VALUE);
+        switch (r) {
+            case 0:
+                return add(modification);
+            case 1:
+                return sub(modification);
+            case 2:
+                return xor(modification);
+            case 3:
+                return explicitValue(modification);
+            case 4:
+                return shiftLeft(shiftModification);
+            case 5:
+                return shiftRight(shiftModification);
+            default:
+                return null;
+        }
+    }
+
+    private UnsignedIntegerModificationFactory() {
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerShiftLeftModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerShiftLeftModification.java
@@ -1,0 +1,92 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "shift", "modificationFilter" })
+public class UnsignedIntegerShiftLeftModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_SHIFT_MODIFIER = 32;
+
+    private int shift;
+
+    public UnsignedIntegerShiftLeftModification() {
+
+    }
+
+    public UnsignedIntegerShiftLeftModification(int shift) {
+        this.shift = shift;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(UnsignedInteger input) {
+        if (input == null) {
+            return UnsignedInteger.ZERO;
+        }
+        return UnsignedInteger.fromIntBits(input.intValue() << shift);
+    }
+
+    public int getShift() {
+        return shift;
+    }
+
+    public void setShift(int shift) {
+        this.shift = shift;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        Random r = new Random();
+        int newShift;
+        if (r.nextBoolean()) {
+            newShift = shift + r.nextInt(MAX_SHIFT_MODIFIER);
+        } else {
+            newShift = shift - r.nextInt(MAX_SHIFT_MODIFIER);
+        }
+        if (newShift < 0) {
+            newShift = MAX_SHIFT_MODIFIER - 1;
+        } else if (newShift > MAX_SHIFT_MODIFIER - 1) {
+            newShift = 0;
+        }
+        return new UnsignedIntegerShiftLeftModification(newShift);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 73 * hash + this.shift;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerShiftLeftModification other = (UnsignedIntegerShiftLeftModification) obj;
+        if (this.shift != other.shift) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerShiftRightModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerShiftRightModification.java
@@ -1,0 +1,92 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "shift", "modificationFilter" })
+public class UnsignedIntegerShiftRightModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_SHIFT_MODIFIER = 32;
+
+    private int shift;
+
+    public UnsignedIntegerShiftRightModification() {
+
+    }
+
+    public UnsignedIntegerShiftRightModification(int shift) {
+        this.shift = shift;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(final UnsignedInteger input) {
+        if (input == null) {
+            return UnsignedInteger.ZERO;
+        }
+        return UnsignedInteger.fromIntBits(input.intValue() >> shift);
+    }
+
+    public int getShift() {
+        return shift;
+    }
+
+    public void setShift(int shift) {
+        this.shift = shift;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        Random r = new Random();
+        int newShift;
+        if (r.nextBoolean()) {
+            newShift = shift + r.nextInt(MAX_SHIFT_MODIFIER);
+        } else {
+            newShift = shift - r.nextInt(MAX_SHIFT_MODIFIER);
+        }
+        if (newShift < 0) {
+            newShift = MAX_SHIFT_MODIFIER - 1;
+        } else if (newShift > MAX_SHIFT_MODIFIER - 1) {
+            newShift = 0;
+        }
+        return new UnsignedIntegerShiftRightModification(newShift);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 59 * hash + this.shift;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerShiftRightModification other = (UnsignedIntegerShiftRightModification) obj;
+        if (this.shift != other.shift) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerSubtractModification.java
@@ -1,0 +1,83 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
+public class UnsignedIntegerSubtractModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_SUBTRACT_MODIFIER = 256;
+
+    private UnsignedInteger subtrahend;
+
+    public UnsignedIntegerSubtractModification() {
+
+    }
+
+    public UnsignedIntegerSubtractModification(Integer bi) {
+        this(bi != null ? UnsignedInteger.fromIntBits(bi) : null);
+    }
+
+    public UnsignedIntegerSubtractModification(UnsignedInteger bi) {
+        this.subtrahend = bi;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(final UnsignedInteger input) {
+        return (input == null) ? UnsignedInteger.ZERO.minus(subtrahend) : input.minus(subtrahend);
+    }
+
+    public UnsignedInteger getSubtrahend() {
+        return subtrahend;
+    }
+
+    public void setSubtrahend(UnsignedInteger subtrahend) {
+        this.subtrahend = subtrahend;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        UnsignedInteger modification = UnsignedInteger.fromIntBits(new Random().nextInt(MAX_SUBTRACT_MODIFIER));
+        return new UnsignedIntegerSubtractModification(subtrahend.plus(modification));
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 23 * hash + Objects.hashCode(this.subtrahend);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerSubtractModification other = (UnsignedIntegerSubtractModification) obj;
+        if (!Objects.equals(this.subtrahend, other.subtrahend)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerSubtractModification.java
@@ -46,6 +46,10 @@ public class UnsignedIntegerSubtractModification extends VariableModification<Un
         return subtrahend;
     }
 
+    public void setSubtrahend(Integer subtrahend) {
+        setSubtrahend(subtrahend != null ? UnsignedInteger.fromIntBits(subtrahend) : null);
+    }
+
     public void setSubtrahend(UnsignedInteger subtrahend) {
         this.subtrahend = subtrahend;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/uinteger/UnsignedIntegerXorModification.java
@@ -1,0 +1,89 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.uinteger;
+
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.VariableModification;
+import de.rub.nds.modifiablevariable.integer.IntegerSubtractModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "xor", "modificationFilter" })
+public class UnsignedIntegerXorModification extends VariableModification<UnsignedInteger> {
+
+    private static final int MAX_VALUE_MODIFIER = 256;
+
+    private UnsignedInteger xor;
+
+    public UnsignedIntegerXorModification() {
+
+    }
+
+    public UnsignedIntegerXorModification(Integer bi) {
+        this(bi != null ? UnsignedInteger.fromIntBits(bi) : null);
+    }
+
+    public UnsignedIntegerXorModification(UnsignedInteger bi) {
+        this.xor = bi;
+    }
+
+    @Override
+    protected UnsignedInteger modifyImplementationHook(final UnsignedInteger input) {
+        return (input == null) ? xor : UnsignedInteger.fromIntBits(input.intValue() ^ xor.intValue());
+    }
+
+    public UnsignedInteger getXor() {
+        return xor;
+    }
+
+    public void setXor(UnsignedInteger xor) {
+        this.xor = xor;
+    }
+
+    @Override
+    public VariableModification<UnsignedInteger> getModifiedCopy() {
+        Random r = new Random();
+        UnsignedInteger modification = UnsignedInteger.fromIntBits(new Random().nextInt(MAX_VALUE_MODIFIER));
+        if (r.nextBoolean()) {
+            return new UnsignedIntegerXorModification(xor.plus(modification));
+        } else {
+            return new UnsignedIntegerXorModification(xor.minus(modification));
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 97 * hash + Objects.hashCode(this.xor);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedIntegerXorModification other = (UnsignedIntegerXorModification) obj;
+        if (!Objects.equals(this.xor, other.xor)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/ModifiableUnsignedLong.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/ModifiableUnsignedLong.java
@@ -7,67 +7,74 @@
  * http://www.apache.org/licenses/LICENSE-2.0.txt
  */
 
-package de.rub.nds.modifiablevariable.uinteger;
+package de.rub.nds.modifiablevariable.ulong;
 
-import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ModifiableUnsignedInteger extends ModifiableVariable<UnsignedInteger> {
+public class ModifiableUnsignedLong extends ModifiableVariable<UnsignedLong> implements Serializable {
 
-    private UnsignedInteger originalValue;
+    private UnsignedLong originalValue;
 
     @Override
     protected void createRandomModification() {
-        VariableModification<UnsignedInteger> vm = UnsignedIntegerModificationFactory.createRandomModification();
+        VariableModification<UnsignedLong> vm = UnsignedLongModificationFactory.createRandomModification();
         setModification(vm);
     }
 
-    public UnsignedInteger getAssertEquals() {
+    public UnsignedLong getAssertEquals() {
         return assertEquals;
     }
 
-    public void setAssertEquals(Integer assertEquals) {
-        setAssertEquals(assertEquals != null ? UnsignedInteger.fromIntBits(assertEquals) : null);
+    public void setAssertEquals(UnsignedLong assertEquals) {
+        this.assertEquals = assertEquals;
     }
 
-    public void setAssertEquals(UnsignedInteger assertEquals) {
-        this.assertEquals = assertEquals;
+    public void setAssertEquals(Long assertEquals) {
+        this.assertEquals = assertEquals != null ? UnsignedLong.fromLongBits(assertEquals) : null;
     }
 
     @Override
     public boolean isOriginalValueModified() {
-        return getOriginalValue() != null && getOriginalValue().compareTo(getValue()) != 0;
+        return originalValue != null && originalValue.compareTo(getValue()) != 0;
     }
 
     @Override
     public boolean validateAssertions() {
-        return assertEquals == null || assertEquals.compareTo(getValue()) == 0;
+        boolean valid = true;
+        if (assertEquals != null) {
+            if (assertEquals.compareTo(getValue()) != 0) {
+                valid = false;
+            }
+        }
+        return valid;
     }
 
     @Override
-    public UnsignedInteger getOriginalValue() {
+    public UnsignedLong getOriginalValue() {
         return originalValue;
     }
 
-    public void setOriginalValue(Integer originalValue) {
-        setOriginalValue(originalValue != null ? UnsignedInteger.fromIntBits(originalValue) : null);
+    @Override
+    public void setOriginalValue(UnsignedLong originalValue) {
+        this.originalValue = originalValue;
     }
 
-    @Override
-    public void setOriginalValue(UnsignedInteger originalValue) {
-        this.originalValue = originalValue;
+    public void setOriginalValue(Long originalValue) {
+        this.originalValue = originalValue != null ? UnsignedLong.fromLongBits(originalValue) : null;
     }
 
     @Override
     public String toString() {
-        return "ModifiableUnsignedInteger{originalValue=" + originalValue + "}";
+        return "ModifiableUnsignedLong{" + "originalValue=" + originalValue + '}';
     }
 
     @Override
@@ -75,11 +82,11 @@ public class ModifiableUnsignedInteger extends ModifiableVariable<UnsignedIntege
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ModifiableUnsignedInteger)) {
+        if (!(o instanceof ModifiableUnsignedLong)) {
             return false;
         }
 
-        ModifiableUnsignedInteger that = (ModifiableUnsignedInteger) o;
+        ModifiableUnsignedLong that = (ModifiableUnsignedLong) o;
 
         return getValue() != null ? getValue().equals(that.getValue()) : that.getValue() == null;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongAddModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongAddModification.java
@@ -1,0 +1,88 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.ulong;
+
+import com.google.common.primitives.UnsignedLong;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "summand", "modificationFilter" })
+public class UnsignedLongAddModification extends VariableModification<UnsignedLong> {
+
+    private static final int MAX_ADD_MODIFIER = 32;
+
+    private UnsignedLong summand;
+
+    public UnsignedLongAddModification() {
+
+    }
+
+    public UnsignedLongAddModification(Long bi) {
+        this(bi != null ? UnsignedLong.fromLongBits(bi) : null);
+    }
+
+    public UnsignedLongAddModification(UnsignedLong bi) {
+        this.summand = bi;
+    }
+
+    @Override
+    protected UnsignedLong modifyImplementationHook(final UnsignedLong input) {
+        return (input == null) ? summand : input.plus(summand);
+    }
+
+    public UnsignedLong getSummand() {
+        return summand;
+    }
+
+    public void setSummand(Long summand) {
+        setSummand(summand != null ? UnsignedLong.fromLongBits(summand) : null);
+    }
+
+    public void setSummand(UnsignedLong summand) {
+        this.summand = summand;
+    }
+
+    @Override
+    public VariableModification<UnsignedLong> getModifiedCopy() {
+        UnsignedLong modification = UnsignedLong.fromLongBits(new Random().nextInt(MAX_ADD_MODIFIER));
+        return new UnsignedLongAddModification(summand.plus(modification));
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 43 * hash + Objects.hashCode(this.summand);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedLongAddModification other = (UnsignedLongAddModification) obj;
+        if (!Objects.equals(this.summand, other.summand)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongExplicitValueModification.java
@@ -1,0 +1,92 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.ulong;
+
+import com.google.common.primitives.UnsignedLong;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "explicitValue", "modificationFilter" })
+public class UnsignedLongExplicitValueModification extends VariableModification<UnsignedLong> {
+
+    private static final int MAX_EXPLICIT_VALUE = 256;
+
+    private UnsignedLong explicitValue;
+
+    public UnsignedLongExplicitValueModification() {
+
+    }
+
+    public UnsignedLongExplicitValueModification(Long bi) {
+        this(bi != null ? UnsignedLong.fromLongBits(bi) : null);
+    }
+
+    public UnsignedLongExplicitValueModification(UnsignedLong bi) {
+        this.explicitValue = bi;
+    }
+
+    @Override
+    protected UnsignedLong modifyImplementationHook(final UnsignedLong input) {
+        return explicitValue;
+    }
+
+    public UnsignedLong getExplicitValue() {
+        return explicitValue;
+    }
+
+    public void setExplicitValue(Long explicitValue) {
+        setExplicitValue(explicitValue != null ? UnsignedLong.fromLongBits(explicitValue) : null);
+    }
+
+    public void setExplicitValue(UnsignedLong explicitValue) {
+        this.explicitValue = explicitValue;
+    }
+
+    @Override
+    public VariableModification<UnsignedLong> getModifiedCopy() {
+        Random r = new Random();
+        UnsignedLong modification = UnsignedLong.fromLongBits(r.nextInt(MAX_EXPLICIT_VALUE));
+        if (r.nextBoolean()) {
+            return new UnsignedLongExplicitValueModification(explicitValue.plus(modification));
+        } else {
+            return new UnsignedLongExplicitValueModification(explicitValue.minus(modification));
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 43 * hash + Objects.hashCode(this.explicitValue);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedLongExplicitValueModification other = (UnsignedLongExplicitValueModification) obj;
+        if (!Objects.equals(this.explicitValue, other.explicitValue)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongModificationFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongModificationFactory.java
@@ -1,0 +1,92 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.ulong;
+
+import com.google.common.primitives.UnsignedLong;
+import de.rub.nds.modifiablevariable.VariableModification;
+import de.rub.nds.modifiablevariable.util.RandomHelper;
+
+import java.util.Random;
+
+public class UnsignedLongModificationFactory {
+
+    private static final int MODIFICATION_COUNT = 4;
+
+    private static final int MAX_MODIFICATION_VALUE = 32000;
+
+    public static UnsignedLongAddModification add(final String summand) {
+        return new UnsignedLongAddModification(UnsignedLong.valueOf(summand));
+    }
+
+    public static UnsignedLongAddModification add(final Long summand) {
+        return new UnsignedLongAddModification(summand);
+    }
+
+    public static UnsignedLongAddModification add(final UnsignedLong summand) {
+        return new UnsignedLongAddModification(summand);
+    }
+
+    public static UnsignedLongSubtractModification sub(final String subtrahend) {
+        return new UnsignedLongSubtractModification(UnsignedLong.valueOf(subtrahend));
+    }
+
+    public static UnsignedLongSubtractModification sub(final Long subtrahend) {
+        return new UnsignedLongSubtractModification(subtrahend);
+    }
+
+    public static UnsignedLongSubtractModification sub(final UnsignedLong subtrahend) {
+        return new UnsignedLongSubtractModification(subtrahend);
+    }
+
+    public static UnsignedLongXorModification xor(final String xor) {
+        return new UnsignedLongXorModification(UnsignedLong.valueOf(xor));
+    }
+
+    public static UnsignedLongXorModification xor(final Long xor) {
+        return new UnsignedLongXorModification(xor);
+    }
+
+    public static UnsignedLongXorModification xor(final UnsignedLong xor) {
+        return new UnsignedLongXorModification(xor);
+    }
+
+    public static UnsignedLongExplicitValueModification explicitValue(final String value) {
+        return new UnsignedLongExplicitValueModification(UnsignedLong.valueOf(value));
+    }
+
+    public static UnsignedLongExplicitValueModification explicitValue(final Long value) {
+        return new UnsignedLongExplicitValueModification(value);
+    }
+
+    public static UnsignedLongExplicitValueModification explicitValue(final UnsignedLong value) {
+        return new UnsignedLongExplicitValueModification(value);
+    }
+
+    public static VariableModification<UnsignedLong> createRandomModification() {
+        Random random = RandomHelper.getRandom();
+        int r = random.nextInt(MODIFICATION_COUNT);
+        int modification = random.nextInt(MAX_MODIFICATION_VALUE);
+        switch (r) {
+            case 0:
+                return add((long) modification);
+            case 1:
+                return sub((long) modification);
+            case 2:
+                return xor((long) modification);
+            case 3:
+                return explicitValue((long) modification);
+            default:
+                return null;
+        }
+    }
+
+    private UnsignedLongModificationFactory() {
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongSubtractModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongSubtractModification.java
@@ -1,0 +1,87 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.ulong;
+
+import com.google.common.primitives.UnsignedLong;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "subtrahend", "modificationFilter" })
+public class UnsignedLongSubtractModification extends VariableModification<UnsignedLong> {
+
+    private static final int MAX_SUBTRACT_MODIFIER = 256;
+
+    private UnsignedLong subtrahend;
+
+    public UnsignedLongSubtractModification() {
+
+    }
+
+    public UnsignedLongSubtractModification(Long bi) {
+        this(bi != null ? UnsignedLong.fromLongBits(bi) : null);
+    }
+
+    public UnsignedLongSubtractModification(UnsignedLong bi) {
+        this.subtrahend = bi;
+    }
+
+    @Override
+    protected UnsignedLong modifyImplementationHook(final UnsignedLong input) {
+        return (input == null) ? UnsignedLong.ZERO.minus(subtrahend) : input.minus(subtrahend);
+    }
+
+    public UnsignedLong getSubtrahend() {
+        return subtrahend;
+    }
+
+    public void setSubtrahend(Long subtrahend) {
+        setSubtrahend(subtrahend != null ? UnsignedLong.fromLongBits(subtrahend) : null);
+    }
+
+    public void setSubtrahend(UnsignedLong subtrahend) {
+        this.subtrahend = subtrahend;
+    }
+
+    @Override
+    public VariableModification<UnsignedLong> getModifiedCopy() {
+        UnsignedLong modification = UnsignedLong.fromLongBits(new Random().nextInt(MAX_SUBTRACT_MODIFIER));
+        return new UnsignedLongSubtractModification(subtrahend.plus(modification));
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.subtrahend);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedLongSubtractModification other = (UnsignedLongSubtractModification) obj;
+        if (!Objects.equals(this.subtrahend, other.subtrahend)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ulong/UnsignedLongXorModification.java
@@ -1,0 +1,92 @@
+/**
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package de.rub.nds.modifiablevariable.ulong;
+
+import com.google.common.primitives.UnsignedLong;
+import de.rub.nds.modifiablevariable.VariableModification;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+import java.util.Random;
+
+@XmlRootElement
+@XmlType(propOrder = { "xor", "modificationFilter" })
+public class UnsignedLongXorModification extends VariableModification<UnsignedLong> {
+
+    private static final int MAX_XOR_MODIFIER = 256;
+
+    private UnsignedLong xor;
+
+    public UnsignedLongXorModification() {
+
+    }
+
+    public UnsignedLongXorModification(Long bi) {
+        this(bi != null ? UnsignedLong.fromLongBits(bi) : null);
+    }
+
+    public UnsignedLongXorModification(UnsignedLong bi) {
+        this.xor = bi;
+    }
+
+    @Override
+    protected UnsignedLong modifyImplementationHook(final UnsignedLong input) {
+        return (input == null) ? xor : UnsignedLong.fromLongBits(input.longValue() ^ xor.longValue());
+    }
+
+    public UnsignedLong getXor() {
+        return xor;
+    }
+
+    public void setXor(Long xor) {
+        setXor(xor != null ? UnsignedLong.fromLongBits(xor) : null);
+    }
+
+    public void setXor(UnsignedLong xor) {
+        this.xor = xor;
+    }
+
+    @Override
+    public VariableModification<UnsignedLong> getModifiedCopy() {
+        Random r = new Random();
+        UnsignedLong modification = UnsignedLong.fromLongBits(new Random().nextInt(MAX_XOR_MODIFIER));
+        if (r.nextBoolean()) {
+            return new UnsignedLongXorModification(xor.plus(modification));
+        } else {
+            return new UnsignedLongXorModification(xor.minus(modification));
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 59 * hash + Objects.hashCode(this.xor);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final UnsignedLongXorModification other = (UnsignedLongXorModification) obj;
+        if (!Objects.equals(this.xor, other.xor)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/util/ArrayConverter.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/ArrayConverter.java
@@ -130,10 +130,10 @@ public class ArrayConverter {
      * @return       long
      */
     public static long bytesToLong(byte[] value) {
-        int result = 0;
+        long result = 0;
         int shift = 0;
         for (int i = value.length - 1; i >= 0; i--) {
-            result += (value[i] & 0xFF) << shift;
+            result += ((long) value[i]) << shift;
             shift += 8;
         }
         return result;
@@ -199,8 +199,7 @@ public class ArrayConverter {
      */
     public static String bytesToRawHexString(byte[] array) {
         StringBuilder result = new StringBuilder();
-        for (int i = 0; i < array.length; i++) {
-            byte b = array[i];
+        for (byte b : array) {
             result.append(String.format("%02X", b));
         }
         return result.toString();

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -10,6 +10,7 @@
 package de.rub.nds.modifiablevariable.util;
 
 import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.biginteger.BigIntegerModificationFactory;
@@ -29,6 +30,8 @@ import de.rub.nds.modifiablevariable.string.ModifiableString;
 import de.rub.nds.modifiablevariable.string.StringModificationFactory;
 import de.rub.nds.modifiablevariable.uinteger.ModifiableUnsignedInteger;
 import de.rub.nds.modifiablevariable.uinteger.UnsignedIntegerModificationFactory;
+import de.rub.nds.modifiablevariable.ulong.ModifiableUnsignedLong;
+import de.rub.nds.modifiablevariable.ulong.UnsignedLongModificationFactory;
 
 import java.math.BigInteger;
 
@@ -74,6 +77,13 @@ public class Modifiable {
         return modifiableLong;
     }
 
+    private static ModifiableUnsignedLong
+        getModifiableUnsignedLongWithModification(VariableModification<UnsignedLong> modification) {
+        ModifiableUnsignedLong modifiableUnsignedLong = new ModifiableUnsignedLong();
+        modifiableUnsignedLong.setModification(modification);
+        return modifiableUnsignedLong;
+    }
+
     private static ModifiableBoolean getModifiableBooleanWithModification(VariableModification<Boolean> modification) {
         ModifiableBoolean modifiableBoolean = new ModifiableBoolean();
         modifiableBoolean.setModification(modification);
@@ -108,6 +118,10 @@ public class Modifiable {
 
     public static ModifiableLong explicit(Long l) {
         return getModifiableLongWithModification(LongModificationFactory.explicitValue(l));
+    }
+
+    public static ModifiableUnsignedLong explicit(UnsignedLong l) {
+        return getModifiableUnsignedLongWithModification(UnsignedLongModificationFactory.explicitValue(l));
     }
 
     public static ModifiableBoolean explicit(Boolean b) {
@@ -151,6 +165,8 @@ public class Modifiable {
             return clazz.cast(explicit(valueString != null ? new BigInteger(valueString) : null));
         } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
             return clazz.cast(explicit(valueString != null ? UnsignedInteger.valueOf(valueString) : null));
+        } else if (clazz.equals(ModifiableUnsignedLong.class)) {
+            return clazz.cast(explicit(valueString != null ? UnsignedLong.valueOf(valueString) : null));
         } else {
             // May happen if the user implements its own subclass and tries to call this method with it
             // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
@@ -182,6 +198,10 @@ public class Modifiable {
 
     public static ModifiableLong xor(Long l) {
         return getModifiableLongWithModification(LongModificationFactory.xor(l));
+    }
+
+    public static ModifiableUnsignedLong xor(UnsignedLong l) {
+        return getModifiableUnsignedLongWithModification(UnsignedLongModificationFactory.xor(l));
     }
 
     /**
@@ -216,6 +236,8 @@ public class Modifiable {
             return clazz.cast(xor(xorString != null ? new BigInteger(xorString) : null));
         } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
             return clazz.cast(xor(xorString != null ? UnsignedInteger.valueOf(xorString) : null));
+        } else if (clazz.equals(ModifiableUnsignedLong.class)) {
+            return clazz.cast(xor(xorString != null ? UnsignedLong.valueOf(xorString) : null));
         } else {
             // May happen if the user implements its own subclass and tries to call this method with it
             // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
@@ -243,6 +265,10 @@ public class Modifiable {
 
     public static ModifiableLong add(Long l) {
         return getModifiableLongWithModification(LongModificationFactory.add(l));
+    }
+
+    public static ModifiableUnsignedLong add(UnsignedLong l) {
+        return getModifiableUnsignedLongWithModification(UnsignedLongModificationFactory.add(l));
     }
 
     /**
@@ -277,6 +303,8 @@ public class Modifiable {
             return clazz.cast(add(summandString != null ? new BigInteger(summandString) : null));
         } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
             return clazz.cast(add(summandString != null ? UnsignedInteger.valueOf(summandString) : null));
+        } else if (clazz.equals(ModifiableUnsignedLong.class)) {
+            return clazz.cast(add(summandString != null ? UnsignedLong.valueOf(summandString) : null));
         } else {
             // May happen if the user implements its own subclass and tries to call this method with it
             // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
@@ -304,6 +332,10 @@ public class Modifiable {
 
     public static ModifiableLong sub(Long l) {
         return getModifiableLongWithModification(LongModificationFactory.sub(l));
+    }
+
+    public static ModifiableUnsignedLong sub(UnsignedLong l) {
+        return getModifiableUnsignedLongWithModification(UnsignedLongModificationFactory.sub(l));
     }
 
     /**
@@ -339,6 +371,8 @@ public class Modifiable {
             return clazz.cast(sub(subtrahendString != null ? new BigInteger(subtrahendString) : null));
         } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
             return clazz.cast(sub(subtrahendString != null ? UnsignedInteger.valueOf(subtrahendString) : null));
+        } else if (clazz.equals(ModifiableUnsignedLong.class)) {
+            return clazz.cast(sub(subtrahendString != null ? UnsignedLong.valueOf(subtrahendString) : null));
         } else {
             // May happen if the user implements its own subclass and tries to call this method with it
             // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -9,6 +9,8 @@
 
 package de.rub.nds.modifiablevariable.util;
 
+import com.google.common.primitives.UnsignedInteger;
+import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.biginteger.BigIntegerModificationFactory;
 import de.rub.nds.modifiablevariable.biginteger.ModifiableBigInteger;
@@ -25,6 +27,9 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteModificationFactory;
 import de.rub.nds.modifiablevariable.singlebyte.ModifiableByte;
 import de.rub.nds.modifiablevariable.string.ModifiableString;
 import de.rub.nds.modifiablevariable.string.StringModificationFactory;
+import de.rub.nds.modifiablevariable.uinteger.ModifiableUnsignedInteger;
+import de.rub.nds.modifiablevariable.uinteger.UnsignedIntegerModificationFactory;
+
 import java.math.BigInteger;
 
 @SuppressWarnings("unused")
@@ -47,6 +52,13 @@ public class Modifiable {
         ModifiableInteger modifiableInteger = new ModifiableInteger();
         modifiableInteger.setModification(modification);
         return modifiableInteger;
+    }
+
+    private static ModifiableUnsignedInteger
+        getModifiableUnsignedIntegerWithModification(VariableModification<UnsignedInteger> modification) {
+        ModifiableUnsignedInteger modifiableUnsignedInteger = new ModifiableUnsignedInteger();
+        modifiableUnsignedInteger.setModification(modification);
+        return modifiableUnsignedInteger;
     }
 
     private static ModifiableBigInteger
@@ -86,6 +98,10 @@ public class Modifiable {
         return getModifiableIntegerWithModification(IntegerModificationFactory.explicitValue(i));
     }
 
+    public static ModifiableUnsignedInteger explicit(UnsignedInteger i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.explicitValue(i));
+    }
+
     public static ModifiableBigInteger explicit(BigInteger i) {
         return getModifiableBigIntegerWithModification(BigIntegerModificationFactory.explicitValue(i));
     }
@@ -114,6 +130,10 @@ public class Modifiable {
         return getModifiableIntegerWithModification(IntegerModificationFactory.xor(i));
     }
 
+    public static ModifiableUnsignedInteger xor(UnsignedInteger i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.xor(i));
+    }
+
     public static ModifiableBigInteger xor(BigInteger i) {
         return getModifiableBigIntegerWithModification(BigIntegerModificationFactory.xor(i));
     }
@@ -130,6 +150,10 @@ public class Modifiable {
         return getModifiableIntegerWithModification(IntegerModificationFactory.add(i));
     }
 
+    public static ModifiableUnsignedInteger add(UnsignedInteger i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.add(i));
+    }
+
     public static ModifiableBigInteger add(BigInteger i) {
         return getModifiableBigIntegerWithModification(BigIntegerModificationFactory.add(i));
     }
@@ -144,6 +168,10 @@ public class Modifiable {
 
     public static ModifiableInteger sub(Integer i) {
         return getModifiableIntegerWithModification(IntegerModificationFactory.sub(i));
+    }
+
+    public static ModifiableUnsignedInteger sub(UnsignedInteger i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.sub(i));
     }
 
     public static ModifiableBigInteger sub(BigInteger i) {
@@ -182,6 +210,10 @@ public class Modifiable {
         return getModifiableIntegerWithModification(IntegerModificationFactory.shiftLeft(i));
     }
 
+    public static ModifiableUnsignedInteger shiftLeftUnsignedInteger(Integer i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.shiftLeft(i));
+    }
+
     public static ModifiableBigInteger shiftRightBigInteger(Integer i) {
         return getModifiableBigIntegerWithModification(BigIntegerModificationFactory.shiftRight(i));
     }
@@ -194,4 +226,7 @@ public class Modifiable {
         return getModifiableIntegerWithModification(IntegerModificationFactory.shiftRight(i));
     }
 
+    public static ModifiableUnsignedInteger shiftRightUnsignedInteger(Integer i) {
+        return getModifiableUnsignedIntegerWithModification(UnsignedIntegerModificationFactory.shiftRight(i));
+    }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -118,6 +118,48 @@ public class Modifiable {
         return getModifiableStringWithModification(StringModificationFactory.explicitValue(s));
     }
 
+    /**
+     * Creates a new modifiable variable with an explicit value modification which replaces the original value.
+     *
+     * @param  value
+     *                                  The explicit value which replaces the original value.
+     * @param  clazz
+     *                                  Class of the modifiable variable to create. If the class is not supported an
+     *                                  {@link IllegalArgumentException} will be thrown.
+     * @return                          A new modifiable variable of the given class with an explicit value
+     *                                  modification.
+     * @param  <N>
+     *                                  Type of the explicit value.
+     * @param  <MV>
+     *                                  Type of the modifiable variable to return.
+     * @throws IllegalArgumentException
+     *                                  Thrown whenever the provided class is not supported.
+     */
+    public static <N extends Number, MV extends ModifiableVariable<? extends Number>> MV explicit(N value,
+        Class<MV> clazz) {
+        if (clazz.equals(ModifiableByte.class)) {
+            return clazz.cast(explicit(value != null ? value.byteValue() : null));
+        } else if (clazz.equals(ModifiableInteger.class)) {
+            return clazz.cast(explicit(value != null ? value.intValue() : null));
+        } else if (clazz.equals(ModifiableLong.class)) {
+            return clazz.cast(explicit(value != null ? value.longValue() : null));
+        }
+        // No ModifiableVariable of primitive type => best effort
+        // We just assume here that the toString() method does a good job at returning a parsable string value
+        String valueString = value != null ? value.toString() : null;
+        if (clazz.equals(ModifiableBigInteger.class)) {
+            return clazz.cast(explicit(valueString != null ? new BigInteger(valueString) : null));
+        } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
+            return clazz.cast(explicit(valueString != null ? UnsignedInteger.valueOf(valueString) : null));
+        } else {
+            // May happen if the user implements its own subclass and tries to call this method with it
+            // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
+            // subclasses (requires Java 17)
+            throw new IllegalArgumentException("Unable to create modifiable variable of class " + clazz.getSimpleName()
+                + " with explicit value modification");
+        }
+    }
+
     public static ModifiableByteArray xor(byte[] b, int position) {
         return getModifiableByteArrayWithModification(ByteArrayModificationFactory.xor(b, position));
     }
@@ -142,6 +184,47 @@ public class Modifiable {
         return getModifiableLongWithModification(LongModificationFactory.xor(l));
     }
 
+    /**
+     * Creates a new modifiable variable with an XOR modification which returns the XOR result of xor and the original
+     * vlaue.
+     *
+     * @param  xor
+     *                                  The xor value which is being xor'ed to the original value.
+     * @param  clazz
+     *                                  Class of the modifiable variable to create. If the class is not supported an
+     *                                  {@link IllegalArgumentException} will be thrown.
+     * @return                          A new modifiable variable of the given class with an XOR modification.
+     * @param  <N>
+     *                                  Type of the xor value.
+     * @param  <MV>
+     *                                  Type of the modifiable variable to return.
+     * @throws IllegalArgumentException
+     *                                  Thrown whenever the provided class is not supported.
+     */
+    public static <N extends Number, MV extends ModifiableVariable<? extends Number>> MV xor(N xor, Class<MV> clazz) {
+        if (clazz.equals(ModifiableByte.class)) {
+            return clazz.cast(xor(xor != null ? xor.byteValue() : null));
+        } else if (clazz.equals(ModifiableInteger.class)) {
+            return clazz.cast(xor(xor != null ? xor.intValue() : null));
+        } else if (clazz.equals(ModifiableLong.class)) {
+            return clazz.cast(xor(xor != null ? xor.longValue() : null));
+        }
+        // No ModifiableVariable of primitive type => best effort
+        // We just assume here that the toString() method does a good job at returning a parsable string value
+        String xorString = xor != null ? xor.toString() : null;
+        if (clazz.equals(ModifiableBigInteger.class)) {
+            return clazz.cast(xor(xorString != null ? new BigInteger(xorString) : null));
+        } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
+            return clazz.cast(xor(xorString != null ? UnsignedInteger.valueOf(xorString) : null));
+        } else {
+            // May happen if the user implements its own subclass and tries to call this method with it
+            // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
+            // subclasses (requires Java 17)
+            throw new IllegalArgumentException(
+                "Unable to create modifiable variable of class " + clazz.getSimpleName() + " with xor modification");
+        }
+    }
+
     public static ModifiableByte add(Byte b) {
         return getModifiableByteWithModification(ByteModificationFactory.add(b));
     }
@@ -162,6 +245,47 @@ public class Modifiable {
         return getModifiableLongWithModification(LongModificationFactory.add(l));
     }
 
+    /**
+     * Creates a new modifiable variable with an add modification which adds the given summand to the original value.
+     *
+     * @param  summand
+     *                                  Value to add to the original value.
+     * @param  clazz
+     *                                  Class of the modifiable variable to create. If the class is not supported an
+     *                                  {@link IllegalArgumentException} will be thrown.
+     * @return                          A new modifiable variable of the given class with an add modification.
+     * @param  <N>
+     *                                  Type of the summand.
+     * @param  <MV>
+     *                                  Type of the modifiable variable to return.
+     * @throws IllegalArgumentException
+     *                                  Thrown whenever the provided class is not supported.
+     */
+    public static <N extends Number, MV extends ModifiableVariable<? extends Number>> MV add(N summand,
+        Class<MV> clazz) {
+        if (clazz.equals(ModifiableByte.class)) {
+            return clazz.cast(add(summand != null ? summand.byteValue() : null));
+        } else if (clazz.equals(ModifiableInteger.class)) {
+            return clazz.cast(add(summand != null ? summand.intValue() : null));
+        } else if (clazz.equals(ModifiableLong.class)) {
+            return clazz.cast(add(summand != null ? summand.longValue() : null));
+        }
+        // No ModifiableVariable of primitive type => best effort
+        // We just assume here that the toString() method does a good job at returning a parsable string value
+        String summandString = summand != null ? summand.toString() : null;
+        if (clazz.equals(ModifiableBigInteger.class)) {
+            return clazz.cast(add(summandString != null ? new BigInteger(summandString) : null));
+        } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
+            return clazz.cast(add(summandString != null ? UnsignedInteger.valueOf(summandString) : null));
+        } else {
+            // May happen if the user implements its own subclass and tries to call this method with it
+            // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
+            // subclasses (requires Java 17)
+            throw new IllegalArgumentException(
+                "Unable to create modifiable variable of class " + clazz.getSimpleName() + " with add modification");
+        }
+    }
+
     public static ModifiableByte sub(Byte b) {
         return getModifiableByteWithModification(ByteModificationFactory.sub(b));
     }
@@ -180,6 +304,48 @@ public class Modifiable {
 
     public static ModifiableLong sub(Long l) {
         return getModifiableLongWithModification(LongModificationFactory.sub(l));
+    }
+
+    /**
+     * Creates a new modifiable variable with a subtract modification which subtracts the given subtrahend from the
+     * original value.
+     *
+     * @param  subtrahend
+     *                                  Value to subtract from the original value.
+     * @param  clazz
+     *                                  Class of the modifiable variable to create. If the class is not supported an
+     *                                  {@link IllegalArgumentException} will be thrown.
+     * @return                          A new modifiable variable of the given class with a subtract modification.
+     * @param  <N>
+     *                                  Type of the subtrahend.
+     * @param  <MV>
+     *                                  Type of the modifiable variable to return.
+     * @throws IllegalArgumentException
+     *                                  Thrown whenever the provided class is not supported.
+     */
+    public static <N extends Number, MV extends ModifiableVariable<? extends Number>> MV sub(N subtrahend,
+        Class<MV> clazz) {
+        if (clazz.equals(ModifiableByte.class)) {
+            return clazz.cast(sub(subtrahend != null ? subtrahend.byteValue() : null));
+        } else if (clazz.equals(ModifiableInteger.class)) {
+            return clazz.cast(sub(subtrahend != null ? subtrahend.intValue() : null));
+        } else if (clazz.equals(ModifiableLong.class)) {
+            return clazz.cast(sub(subtrahend != null ? subtrahend.longValue() : null));
+        }
+        // No ModifiableVariable of primitive type => best effort
+        // We just assume here that the toString() method does a good job at returning a parsable string value
+        String subtrahendString = subtrahend != null ? subtrahend.toString() : null;
+        if (clazz.equals(ModifiableBigInteger.class)) {
+            return clazz.cast(sub(subtrahendString != null ? new BigInteger(subtrahendString) : null));
+        } else if (clazz.equals(ModifiableUnsignedInteger.class)) {
+            return clazz.cast(sub(subtrahendString != null ? UnsignedInteger.valueOf(subtrahendString) : null));
+        } else {
+            // May happen if the user implements its own subclass and tries to call this method with it
+            // TODO: This can be avoided by implementing a sealed class with all supported classes as permitted
+            // subclasses (requires Java 17)
+            throw new IllegalArgumentException("Unable to create modifiable variable of class " + clazz.getSimpleName()
+                + " with subtract modification");
+        }
     }
 
     public static ModifiableByteArray insert(byte[] b, int position) {


### PR DESCRIPTION
The SSH standard defines the `uint32` and `uint64` data types, however there is no equivalent Java and this library. As of now, one may use `int` and `ModifiableInteger` and treat their value as unsigned (Java even added an Unsigned API with version 8). The issue arises that one can only distinguish between signed and unsigned values by in-depth knowledge of the protocol (in case of SSH). This also poses the threat that unsigned values are treated as signed and vise-versa. Although some arithmetic operation (addition, subtraction) and bitwise logical operations are independent from the fact whether an integer is signed or unsigned, this is not true for i. e. multiplication, division and modulo operations.
This PR adds two additional modifiable datatypes for the `UnsignedInteger` and `UnsignedLong` datatypes (from the Guava library, which is used in almost all projects throughout the TLS-* and SSH-* landscape) as well as corresponding modifications adapted from their signed counterparts.
The convenience methods  `add`, `sub`, `xor`, and `explicit` from the `Modifiable` class are now offering a generic approach in addition to their statically typed variants (which always return the modifiable data type corresponding to the data type of the parameter, i. e. Integer -> ModifiableInteger). For example, the following snippet creates a ModifiableBigInteger with an add modification although the summand is given as byte: `add((byte) 0x20, ModifiableBigInteger.class);`

Unit tests for both data types are yet to be implemented, this will be done as soon as #86 has been merged into master.
