### PR TITLE
build: Implement BOM dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,24 @@
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
+# Eclipse
+**/.classpath
+**/.project
+**/.settings/
+.project
+
+# Netbeans
+nbproject/
+nbactions.xml.project
+nbactions.xml
+
+# IntelliJ
+.idea/
+*.iml
+
+# VS Code
+.vscode/
+.factorypath
+
+# Maven
+pom.xml.*
 release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
-/nbproject/
-*.idea/
-ModifiableVariable.iml
+target/
+.flattened-pom.xml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to compile and use ModifiableVariable, you need to have Java and Maven 
 ```bash
 $ sudo apt-get install maven
 ```
-ModifiableVariable currently needs Java JDK 8 to run. If you have the correct Java version you can install
+ModifiableVariable currently needs Java JDK 11 to run. If you have the correct Java version you can install
  ModifiableVariable as follows.
 ```bash
 $ git clone https://github.com/tls-attacker/ModifiableVariable.git
@@ -26,8 +26,8 @@ If you want to use this project as a dependency, you do not have to compile it y
 ```xml
 <dependency>
     <groupId>de.rub.nds</groupId>
-    <artifactId>ModifiableVariable</artifactId>
-    <version>3.1.0</version>
+    <artifactId>modifiable-variable</artifactId>
+    <version>4.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.rub.nds</groupId>
+        <artifactId>protocol-toolkit-bom</artifactId>
+        <version>1.0.0</version>
+    </parent>
 
-    <groupId>de.rub.nds</groupId>
-    <artifactId>ModifiableVariable</artifactId>
+    <artifactId>modifiable-variable</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
@@ -18,18 +22,36 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>rub-nexus</id>
-            <name>TLS-Attacker Internal Repository</name>
+            <name>Nexus Internal Repository (SNAPSHOT)</name>
             <url>https://hydrogen.cloud.nds.rub.de/nexus/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>rub-nexus</id>
+            <name>Nexus Internal Repository</name>
+            <url>https://hydrogen.cloud.nds.rub.de/nexus/repository/maven-releases/</url>
         </repository>
     </distributionManagement>
+
+    <profiles>
+        <!-- Deployment to Maven Central is done by activating this profile via -P maven-release -->
+        <profile>
+            <id>maven-release</id>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <properties>
+                <!-- Artifacts pushed to maven central must be signed -->
+                <skip.signature>false</skip.signature>
+            </properties>
+        </profile>
+    </profiles>
   
     <developers>
         <developer>
@@ -68,33 +90,27 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
         </dependency>
         <!-- scope: test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -105,14 +121,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.2.0</version>
             </plugin>
             <!--################# default lifecycle plugins #################-->
             <!-- Enforce maven and java version -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -136,7 +150,6 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.20.0</version>
                 <configuration>
                     <configFile>${project.basedir}/maven-eclipse-codestyle.xml</configFile>
                 </configuration>
@@ -152,7 +165,6 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>4.1</version>
                 <configuration>
                     <header>${project.basedir}/license_header_plain.txt</header>
                     <strictCheck>true</strictCheck>
@@ -185,13 +197,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.0</version>
             </plugin>
             <!-- Compile source files -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -201,19 +211,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
             </plugin>
             <!-- Build jar file -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
             </plugin>
             <!-- Compile javadoc -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <javadocExecutable>
@@ -233,7 +240,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -247,7 +253,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -264,13 +269,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>3.0.1</version>
             </plugin>
             <!-- Artifact deployment to OSSRH -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -284,20 +287,11 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.12.0</version>
             </plugin>
             <!-- Codestyle -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.2.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>10.3.1</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <configLocation>${project.basedir}/checkstyle.xml</configLocation>
                     <violationSeverity>info</violationSeverity>
@@ -313,8 +307,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
-        <!-- We redefine the signature generation process, which is enabled by default,
-        but cannot be performed by typical users. Enable it using -Dskip.signature=false -->
         <skip.signature>true</skip.signature>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,11 @@
     <parent>
         <groupId>de.rub.nds</groupId>
         <artifactId>protocol-toolkit-bom</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>modifiable-variable</artifactId>
     <version>3.6.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
     
     <name>ModifiableVariable</name>
     <description>A Modifiable Variable concept allows for easy runtime modifications of basic data types like integers, booleans, or byte arrays</description>
@@ -22,36 +21,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>rub-nexus</id>
-            <name>Nexus Internal Repository (SNAPSHOT)</name>
-            <url>https://hydrogen.cloud.nds.rub.de/nexus/repository/maven-snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>rub-nexus</id>
-            <name>Nexus Internal Repository</name>
-            <url>https://hydrogen.cloud.nds.rub.de/nexus/repository/maven-releases/</url>
-        </repository>
-    </distributionManagement>
-
-    <profiles>
-        <!-- Deployment to Maven Central is done by activating this profile via -P maven-release -->
-        <profile>
-            <id>maven-release</id>
-            <distributionManagement>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
-            <properties>
-                <!-- Artifacts pushed to maven central must be signed -->
-                <skip.signature>false</skip.signature>
-            </properties>
-        </profile>
-    </profiles>
   
     <developers>
         <developer>
@@ -123,29 +92,6 @@
                 <artifactId>maven-clean-plugin</artifactId>
             </plugin>
             <!--################# default lifecycle plugins #################-->
-            <!-- Enforce maven and java version -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.6</version>
-                                </requireMavenVersion>
-                                <requireJavaVersion>
-                                    <version>${maven.compiler.source}</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Formatting -->
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
@@ -249,45 +195,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Sign artifacts -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skip>${skip.signature}</skip>
-                </configuration>
-            </plugin>
-            <!-- Install artifacts to local maven repository -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-            </plugin>
-            <!-- Artifact deployment to OSSRH -->
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <!-- deploy with the following command: mvn nexus-staging:release -->
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
             <!--############ plugins without lifecycle bindings #############-->
-            <!-- Dependency version management -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-            </plugin>
             <!-- Codestyle -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -307,6 +215,5 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
-        <skip.signature>true</skip.signature>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds</groupId>
         <artifactId>protocol-toolkit-bom</artifactId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>modifiable-variable</artifactId>
@@ -135,6 +135,30 @@
                         <phase>process-sources</phase>
                         <goals>
                             <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Flatten pom.xml before install / deploy phases -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
tl;dr:

- pom.xml now inherits `protocol-toolkit-bom` for dependency management
  - Explicit versions of common dependencies and plugins have been removed
- `artifactId` has been changed to `modifiable-variable` to comply with maven guidelines