### PR TITLE
Add support for more String modifications

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -1,12 +1,10 @@
-/**
+/*
  * ModifiableVariable - A Variable Concept for Runtime Modifications
  *
- * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
- * Licensed under Apache License, Version 2.0
- * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package de.rub.nds.modifiablevariable;
 
 import de.rub.nds.modifiablevariable.biginteger.BigIntegerAddModification;
@@ -41,22 +39,19 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteExplicitValueModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
 import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
-import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
-import java.io.Serializable;
-import java.util.Objects;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
- * The base abstract class for modifiable variables, including the getValue function.The class needs to be defined
- * transient to allow propOrder definition in subclasses, see:
+ * The base abstract class for modifiable variables, including the getValue function.The class needs
+ * to be defined transient to allow propOrder definition in subclasses, see:
  * http://blog.bdoughan.com/2011/06/ignoring-inheritance-with-xmltransient.html
- *
  *
  * @param <E>
  */
@@ -65,47 +60,100 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @XmlAccessorType(XmlAccessType.FIELD)
 public abstract class ModifiableVariable<E> implements Serializable {
 
-    @XmlElements(value = { @XmlElement(type = BigIntegerXorModification.class, name = "BigIntegerXorModification"),
-        @XmlElement(type = BigIntegerSubtractModification.class, name = "BigIntegerSubtractModification"),
-        @XmlElement(type = BigIntegerShiftRightModification.class, name = "BigIntegerShiftRightModification"),
-        @XmlElement(type = BigIntegerShiftLeftModification.class, name = "BigIntegerShiftLeftModification"),
-        @XmlElement(type = BigIntegerExplicitValueModification.class, name = "BigIntegerExplicitValueModification"),
-        @XmlElement(type = BigIntegerAddModification.class, name = "BigIntegerAddModification"),
-        @XmlElement(type = BigIntegerInteractiveModification.class, name = "BigIntegerInteractiveModification"),
-        @XmlElement(type = BigIntegerMultiplyModification.class, name = "BigIntegerMultiplyModification"),
-        @XmlElement(type = BooleanToggleModification.class, name = "BooleanToggleModification"),
-        @XmlElement(type = BooleanExplicitValueModification.class, name = "BooleanExplicitValueModification"),
-        @XmlElement(type = ByteArrayXorModification.class, name = "ByteArrayXorModification"),
-        @XmlElement(type = ByteArrayShuffleModification.class, name = "ByteArrayShuffleModification"),
-        @XmlElement(type = ByteArrayPayloadModification.class, name = "ByteArrayPayloadModification"),
-        @XmlElement(type = ByteArrayInsertModification.class, name = "ByteArrayInsertModification"),
-        @XmlElement(type = ByteArrayExplicitValueModification.class, name = "ByteArrayExplicitValueModification"),
-        @XmlElement(type = ByteArrayDuplicateModification.class, name = "ByteArrayDuplicateModification"),
-        @XmlElement(type = ByteArrayDeleteModification.class, name = "ByteArrayDeleteModification"),
-        @XmlElement(type = IntegerXorModification.class, name = "IntegerXorModification"),
-        @XmlElement(type = IntegerSubtractModification.class, name = "IntegerSubtractModification"),
-        @XmlElement(type = IntegerShiftRightModification.class, name = "IntegerShiftRightModification"),
-        @XmlElement(type = IntegerShiftLeftModification.class, name = "IntegerShiftLeftModification"),
-        @XmlElement(type = IntegerExplicitValueModification.class, name = "IntegerExplicitValueModification"),
-        @XmlElement(type = IntegerAddModification.class, name = "IntegerAddModification"),
-        @XmlElement(type = LongXorModification.class, name = "LongXorModification"),
-        @XmlElement(type = LongSubtractModification.class, name = "LongSubtractModification"),
-        @XmlElement(type = LongExplicitValueModification.class, name = "LongExplicitValueModification"),
-        @XmlElement(type = LongAddModification.class, name = "LongAddModification"),
-        @XmlElement(type = ByteXorModification.class, name = "ByteXorModification"),
-        @XmlElement(type = ByteSubtractModification.class, name = "ByteSubtractModification"),
-        @XmlElement(type = ByteAddModification.class, name = "ByteAddModification"),
-        @XmlElement(type = ByteExplicitValueModification.class, name = "ByteExplicitValueModification"),
-        @XmlElement(type = StringExplicitValueModification.class, name = "StringExplicitValueModification") })
+    @XmlElements(
+            value = {
+                @XmlElement(
+                        type = BigIntegerXorModification.class,
+                        name = "BigIntegerXorModification"),
+                @XmlElement(
+                        type = BigIntegerSubtractModification.class,
+                        name = "BigIntegerSubtractModification"),
+                @XmlElement(
+                        type = BigIntegerShiftRightModification.class,
+                        name = "BigIntegerShiftRightModification"),
+                @XmlElement(
+                        type = BigIntegerShiftLeftModification.class,
+                        name = "BigIntegerShiftLeftModification"),
+                @XmlElement(
+                        type = BigIntegerExplicitValueModification.class,
+                        name = "BigIntegerExplicitValueModification"),
+                @XmlElement(
+                        type = BigIntegerAddModification.class,
+                        name = "BigIntegerAddModification"),
+                @XmlElement(
+                        type = BigIntegerInteractiveModification.class,
+                        name = "BigIntegerInteractiveModification"),
+                @XmlElement(
+                        type = BigIntegerMultiplyModification.class,
+                        name = "BigIntegerMultiplyModification"),
+                @XmlElement(
+                        type = BooleanToggleModification.class,
+                        name = "BooleanToggleModification"),
+                @XmlElement(
+                        type = BooleanExplicitValueModification.class,
+                        name = "BooleanExplicitValueModification"),
+                @XmlElement(
+                        type = ByteArrayXorModification.class,
+                        name = "ByteArrayXorModification"),
+                @XmlElement(
+                        type = ByteArrayShuffleModification.class,
+                        name = "ByteArrayShuffleModification"),
+                @XmlElement(
+                        type = ByteArrayPayloadModification.class,
+                        name = "ByteArrayPayloadModification"),
+                @XmlElement(
+                        type = ByteArrayInsertModification.class,
+                        name = "ByteArrayInsertModification"),
+                @XmlElement(
+                        type = ByteArrayExplicitValueModification.class,
+                        name = "ByteArrayExplicitValueModification"),
+                @XmlElement(
+                        type = ByteArrayDuplicateModification.class,
+                        name = "ByteArrayDuplicateModification"),
+                @XmlElement(
+                        type = ByteArrayDeleteModification.class,
+                        name = "ByteArrayDeleteModification"),
+                @XmlElement(type = IntegerXorModification.class, name = "IntegerXorModification"),
+                @XmlElement(
+                        type = IntegerSubtractModification.class,
+                        name = "IntegerSubtractModification"),
+                @XmlElement(
+                        type = IntegerShiftRightModification.class,
+                        name = "IntegerShiftRightModification"),
+                @XmlElement(
+                        type = IntegerShiftLeftModification.class,
+                        name = "IntegerShiftLeftModification"),
+                @XmlElement(
+                        type = IntegerExplicitValueModification.class,
+                        name = "IntegerExplicitValueModification"),
+                @XmlElement(type = IntegerAddModification.class, name = "IntegerAddModification"),
+                @XmlElement(type = LongXorModification.class, name = "LongXorModification"),
+                @XmlElement(
+                        type = LongSubtractModification.class,
+                        name = "LongSubtractModification"),
+                @XmlElement(
+                        type = LongExplicitValueModification.class,
+                        name = "LongExplicitValueModification"),
+                @XmlElement(type = LongAddModification.class, name = "LongAddModification"),
+                @XmlElement(type = ByteXorModification.class, name = "ByteXorModification"),
+                @XmlElement(
+                        type = ByteSubtractModification.class,
+                        name = "ByteSubtractModification"),
+                @XmlElement(type = ByteAddModification.class, name = "ByteAddModification"),
+                @XmlElement(
+                        type = ByteExplicitValueModification.class,
+                        name = "ByteExplicitValueModification"),
+                @XmlElement(
+                        type = StringExplicitValueModification.class,
+                        name = "StringExplicitValueModification")
+            })
     private VariableModification<E> modification = null;
 
     private Boolean createRandomModification;
 
     protected E assertEquals;
 
-    public ModifiableVariable() {
-
-    }
+    public ModifiableVariable() {}
 
     public void setModification(VariableModification<E> modification) {
         this.modification = modification;

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -40,6 +40,7 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
 import de.rub.nds.modifiablevariable.string.StringAppendValueModification;
 import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
+import de.rub.nds.modifiablevariable.string.StringPrependValueModification;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -144,6 +145,9 @@ public abstract class ModifiableVariable<E> implements Serializable {
                 @XmlElement(
                         type = ByteExplicitValueModification.class,
                         name = "ByteExplicitValueModification"),
+                @XmlElement(
+                        type = StringPrependValueModification.class,
+                        name = "StringPrependValueModification"),
                 @XmlElement(
                         type = StringAppendValueModification.class,
                         name = "StringAppendValueModification"),

--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -38,6 +38,7 @@ import de.rub.nds.modifiablevariable.singlebyte.ByteAddModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteExplicitValueModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteSubtractModification;
 import de.rub.nds.modifiablevariable.singlebyte.ByteXorModification;
+import de.rub.nds.modifiablevariable.string.StringAppendValueModification;
 import de.rub.nds.modifiablevariable.string.StringExplicitValueModification;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -143,6 +144,9 @@ public abstract class ModifiableVariable<E> implements Serializable {
                 @XmlElement(
                         type = ByteExplicitValueModification.class,
                         name = "ByteExplicitValueModification"),
+                @XmlElement(
+                        type = StringAppendValueModification.class,
+                        name = "StringAppendValueModification"),
                 @XmlElement(
                         type = StringExplicitValueModification.class,
                         name = "StringExplicitValueModification")

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringAppendValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringAppendValueModification.java
@@ -1,0 +1,70 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.string;
+
+import de.rub.nds.modifiablevariable.VariableModification;
+import de.rub.nds.modifiablevariable.util.IllegalStringAdapter;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Objects;
+
+/** Modification that appends a string to the original value. */
+@XmlRootElement
+@XmlType(propOrder = {"appendValue", "modificationFilter"})
+public class StringAppendValueModification extends VariableModification<String> {
+
+    @XmlJavaTypeAdapter(IllegalStringAdapter.class)
+    private String appendValue;
+
+    public StringAppendValueModification() {}
+
+    public StringAppendValueModification(final String appendValue) {
+        this.appendValue = appendValue;
+    }
+
+    @Override
+    protected String modifyImplementationHook(final String input) {
+        return input + this.appendValue;
+    }
+
+    public String getAppendValue() {
+        return this.appendValue;
+    }
+
+    public void setAppendValue(final String appendValue) {
+        this.appendValue = appendValue;
+    }
+
+    @Override
+    public VariableModification<String> getModifiedCopy() {
+        return new StringAppendValueModification(appendValue);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 4;
+        hash = 83 * hash + Objects.hashCode(this.appendValue);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final StringAppendValueModification other = (StringAppendValueModification) obj;
+        return Objects.equals(this.appendValue, other.getAppendValue());
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
@@ -15,6 +15,10 @@ public class StringModificationFactory {
 
     private static final int MAX_BYTE_LENGTH = 1000;
 
+    public static VariableModification<String> prependValue(final String value) {
+        return new StringPrependValueModification(value);
+    }
+
     public static VariableModification<String> appendValue(final String value) {
         return new StringAppendValueModification(value);
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
@@ -15,6 +15,10 @@ public class StringModificationFactory {
 
     private static final int MAX_BYTE_LENGTH = 1000;
 
+    public static VariableModification<String> appendValue(final String value) {
+        return new StringAppendValueModification(value);
+    }
+
     public static VariableModification<String> explicitValue(final String value) {
         return new StringExplicitValueModification(value);
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringModificationFactory.java
@@ -1,20 +1,16 @@
-/**
+/*
  * ModifiableVariable - A Variable Concept for Runtime Modifications
  *
- * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
- * Licensed under Apache License, Version 2.0
- * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package de.rub.nds.modifiablevariable.string;
 
 import de.rub.nds.modifiablevariable.VariableModification;
 import de.rub.nds.modifiablevariable.util.RandomHelper;
 
-/**
- *
- */
+/** */
 public class StringModificationFactory {
 
     private static final int MAX_BYTE_LENGTH = 1000;

--- a/src/main/java/de/rub/nds/modifiablevariable/string/StringPrependValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/string/StringPrependValueModification.java
@@ -1,0 +1,70 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.string;
+
+import de.rub.nds.modifiablevariable.VariableModification;
+import de.rub.nds.modifiablevariable.util.IllegalStringAdapter;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Objects;
+
+/** Modification that prepends a string to the original value. */
+@XmlRootElement
+@XmlType(propOrder = {"prependValue", "modificationFilter"})
+public class StringPrependValueModification extends VariableModification<String> {
+
+    @XmlJavaTypeAdapter(IllegalStringAdapter.class)
+    private String prependValue;
+
+    public StringPrependValueModification() {}
+
+    public StringPrependValueModification(final String prependValue) {
+        this.prependValue = prependValue;
+    }
+
+    @Override
+    protected String modifyImplementationHook(final String input) {
+        return this.prependValue + input;
+    }
+
+    public String getPrependValue() {
+        return this.prependValue;
+    }
+
+    public void setPrependValue(final String prependValue) {
+        this.prependValue = prependValue;
+    }
+
+    @Override
+    public VariableModification<String> getModifiedCopy() {
+        return new StringPrependValueModification(prependValue);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 83 * hash + Objects.hashCode(this.prependValue);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final StringPrependValueModification other = (StringPrependValueModification) obj;
+        return Objects.equals(this.prependValue, other.getPrependValue());
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -77,6 +77,10 @@ public class Modifiable {
         return modifiableString;
     }
 
+    public static ModifiableString append(final String s) {
+        return getModifiableStringWithModification(StringModificationFactory.appendValue(s));
+    }
+
     public static ModifiableByteArray explicit(byte[] b) {
         return getModifiableByteArrayWithModification(
                 ByteArrayModificationFactory.explicitValue(b));

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -77,6 +77,10 @@ public class Modifiable {
         return modifiableString;
     }
 
+    public static ModifiableString prepend(final String s) {
+        return getModifiableStringWithModification(StringModificationFactory.prependValue(s));
+    }
+
     public static ModifiableString append(final String s) {
         return getModifiableStringWithModification(StringModificationFactory.appendValue(s));
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/Modifiable.java
@@ -1,12 +1,10 @@
-/**
+/*
  * ModifiableVariable - A Variable Concept for Runtime Modifications
  *
- * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
- * Licensed under Apache License, Version 2.0
- * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package de.rub.nds.modifiablevariable.util;
 
 import de.rub.nds.modifiablevariable.VariableModification;
@@ -30,52 +28,58 @@ import java.math.BigInteger;
 @SuppressWarnings("unused")
 public class Modifiable {
 
-    private static ModifiableByteArray
-        getModifiableByteArrayWithModification(VariableModification<byte[]> modification) {
+    private static ModifiableByteArray getModifiableByteArrayWithModification(
+            VariableModification<byte[]> modification) {
         ModifiableByteArray modifiableByteArray = new ModifiableByteArray();
         modifiableByteArray.setModification(modification);
         return modifiableByteArray;
     }
 
-    private static ModifiableByte getModifiableByteWithModification(VariableModification<Byte> modification) {
+    private static ModifiableByte getModifiableByteWithModification(
+            VariableModification<Byte> modification) {
         ModifiableByte modifiableByte = new ModifiableByte();
         modifiableByte.setModification(modification);
         return modifiableByte;
     }
 
-    private static ModifiableInteger getModifiableIntegerWithModification(VariableModification<Integer> modification) {
+    private static ModifiableInteger getModifiableIntegerWithModification(
+            VariableModification<Integer> modification) {
         ModifiableInteger modifiableInteger = new ModifiableInteger();
         modifiableInteger.setModification(modification);
         return modifiableInteger;
     }
 
-    private static ModifiableBigInteger
-        getModifiableBigIntegerWithModification(VariableModification<BigInteger> modification) {
+    private static ModifiableBigInteger getModifiableBigIntegerWithModification(
+            VariableModification<BigInteger> modification) {
         ModifiableBigInteger modifiableBigInteger = new ModifiableBigInteger();
         modifiableBigInteger.setModification(modification);
         return modifiableBigInteger;
     }
 
-    private static ModifiableLong getModifiableLongWithModification(VariableModification<Long> modification) {
+    private static ModifiableLong getModifiableLongWithModification(
+            VariableModification<Long> modification) {
         ModifiableLong modifiableLong = new ModifiableLong();
         modifiableLong.setModification(modification);
         return modifiableLong;
     }
 
-    private static ModifiableBoolean getModifiableBooleanWithModification(VariableModification<Boolean> modification) {
+    private static ModifiableBoolean getModifiableBooleanWithModification(
+            VariableModification<Boolean> modification) {
         ModifiableBoolean modifiableBoolean = new ModifiableBoolean();
         modifiableBoolean.setModification(modification);
         return modifiableBoolean;
     }
 
-    private static ModifiableString getModifiableStringWithModification(VariableModification<String> modification) {
+    private static ModifiableString getModifiableStringWithModification(
+            VariableModification<String> modification) {
         ModifiableString modifiableString = new ModifiableString();
         modifiableString.setModification(modification);
         return modifiableString;
     }
 
     public static ModifiableByteArray explicit(byte[] b) {
-        return getModifiableByteArrayWithModification(ByteArrayModificationFactory.explicitValue(b));
+        return getModifiableByteArrayWithModification(
+                ByteArrayModificationFactory.explicitValue(b));
     }
 
     public static ModifiableByte explicit(Byte b) {
@@ -87,7 +91,8 @@ public class Modifiable {
     }
 
     public static ModifiableBigInteger explicit(BigInteger i) {
-        return getModifiableBigIntegerWithModification(BigIntegerModificationFactory.explicitValue(i));
+        return getModifiableBigIntegerWithModification(
+                BigIntegerModificationFactory.explicitValue(i));
     }
 
     public static ModifiableLong explicit(Long l) {
@@ -103,7 +108,8 @@ public class Modifiable {
     }
 
     public static ModifiableByteArray xor(byte[] b, int position) {
-        return getModifiableByteArrayWithModification(ByteArrayModificationFactory.xor(b, position));
+        return getModifiableByteArrayWithModification(
+                ByteArrayModificationFactory.xor(b, position));
     }
 
     public static ModifiableByte xor(Byte b) {
@@ -155,15 +161,18 @@ public class Modifiable {
     }
 
     public static ModifiableByteArray insert(byte[] b, int position) {
-        return getModifiableByteArrayWithModification(ByteArrayModificationFactory.insert(b, position));
+        return getModifiableByteArrayWithModification(
+                ByteArrayModificationFactory.insert(b, position));
     }
 
     public static ModifiableByteArray delete(int startPosition, int count) {
-        return getModifiableByteArrayWithModification(ByteArrayModificationFactory.delete(startPosition, count));
+        return getModifiableByteArrayWithModification(
+                ByteArrayModificationFactory.delete(startPosition, count));
     }
 
     public static ModifiableByteArray shuffle(byte[] shuffle) {
-        return getModifiableByteArrayWithModification(ByteArrayModificationFactory.shuffle(shuffle));
+        return getModifiableByteArrayWithModification(
+                ByteArrayModificationFactory.shuffle(shuffle));
     }
 
     public static ModifiableByteArray duplicate() {
@@ -193,5 +202,4 @@ public class Modifiable {
     public static ModifiableInteger shiftRight(Integer i) {
         return getModifiableIntegerWithModification(IntegerModificationFactory.shiftRight(i));
     }
-
 }


### PR DESCRIPTION
Currently, only explicit values are supported as string modifications. This adds support for prepending/appending a value to the original string.

The first commit only adds unrelated code style changes and thus makes this PR a bit harder to review, but unfortunately this was necessary because otherwise CI fails.