### PR TITLE
Removed logging of corrupted strings during testing

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/util/IllegalStringAdapterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/IllegalStringAdapterTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -34,10 +33,7 @@ public class IllegalStringAdapterTest {
                                 new String(data, StandardCharsets.ISO_8859_1)
                                         .getBytes(StandardCharsets.ISO_8859_1)));
         String marshal = instance.marshal(new String(data, StandardCharsets.ISO_8859_1));
-        LOGGER.info("Marshal: " + marshal);
         String unmarshal = instance.unmarshal(marshal);
-        LOGGER.info("Unescaped:" + StringEscapeUtils.unescapeXml(unmarshal));
-        LOGGER.info("Unmarshal: " + unmarshal);
         assertArrayEquals(data, unmarshal.getBytes(StandardCharsets.ISO_8859_1));
     }
 }


### PR DESCRIPTION
When building the project the maven output is corrupted because the test outputs garbage data. This fixes this.