### PR TITLE
build: Switch to Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@ pipeline {
     agent any
 
     environment {
-        JDK_TOOL_NAME = 'JDK 11'
-        MAVEN_TOOL_NAME = 'Maven 3.8.6'
+        JDK_TOOL_NAME = 'JDK 21'
+        MAVEN_TOOL_NAME = 'Maven 3.9.6'
     }
 
     options {

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- The following variables are required for Jenkins CI -->
         <skipTests>false</skipTests>
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -115,7 +115,7 @@
                             <spacesPerTab>4</spacesPerTab>
                         </indent>
                         <googleJavaFormat>
-                            <version>1.16.0</version>
+                            <version>1.20.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                         <licenseHeader>


### PR DESCRIPTION
This PR switches the default JDK used to build ModifiableVariable over to JDK21 (was JDK11). OpenJDK 11 will go end-of-life in October 2024, therefore justifying an upgrade to the latest LTS release.

tl;dr:

- Upgrade `maven.compiler.source` and `maven.compiler.target` to 21 to enforce compilation with Java 21 (enforced by enforcer plugin). Compilation attempts with any version older than 21 will fail.
- Update `googleJavaFormat` to 1.20.0 to support Java 21 syntax formatting.
- Update `Jenkinsfile` to reference updated tool names. Jenkins has been configured to handle Java 21 projects.

This patch can be safely merged even though downstream projects are still using Java 11 as the BOM file currently pinpoints a Java 11 build of ModifiableVariable.