### PR TITLE
chore: Make jaxb-runtime a test-only dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <!-- scope: test -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
+            <scope>test</scope>
         </dependency>
-        <!-- scope: test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
This PR reduces the scope of the `jaxb-runtime` dependency to test-only. `jaxb-runtime` is required to perform actual (de-)serialization using XML bindings which is not required outside of unit tests for this library.