### PR TITLE
Update README to reference Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,7 @@ $ cd ModifiableVariable
 $ mvn clean install
 ```
 
-If you want to use this project as a dependency, you do not have to compile it yourself and can include it in your pom.xml as follows:
-
-```xml
-<dependency>
-    <groupId>de.rub.nds</groupId>
-    <artifactId>modifiable-variable</artifactId>
-    <version>5.0.1</version>
-</dependency>
-```
+If you want to use this project as a dependency, you do not have to compile it yourself. You can find the latest version on [Maven Central](https://central.sonatype.com/artifact/de.rub.nds/modifiable-variable/overview).
 
 # Usage
 


### PR DESCRIPTION
## Summary
- Updated the README to reference Maven Central for dependency information instead of hardcoding a specific version
- This ensures users always find the latest version without README updates being required for each release

Fixes #132