### PR TITLE
Fix PMD UnusedFormalParameter warnings

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
@@ -32,6 +32,7 @@ public class BooleanToggleModification extends VariableModification<Boolean> {
      *
      * @param other The modification to copy
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     public BooleanToggleModification(BooleanToggleModification other) {
         super();
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
@@ -36,6 +36,7 @@ public class ByteArrayDuplicateModification extends VariableModification<byte[]>
      *
      * @param other The modification to copy
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     public ByteArrayDuplicateModification(ByteArrayDuplicateModification other) {
         super();
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerSwapEndianModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/IntegerSwapEndianModification.java
@@ -38,6 +38,7 @@ public class IntegerSwapEndianModification extends VariableModification<Integer>
      *
      * @param other The modification to copy
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     public IntegerSwapEndianModification(IntegerSwapEndianModification other) {
         super();
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/longint/LongSwapEndianModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/longint/LongSwapEndianModification.java
@@ -36,6 +36,7 @@ public class LongSwapEndianModification extends VariableModification<Long> {
      *
      * @param other The modification to copy
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     public LongSwapEndianModification(LongSwapEndianModification other) {
         super();
     }


### PR DESCRIPTION
## Summary
- Fixed PMD UnusedFormalParameter warnings in 4 modification classes
- Added @SuppressWarnings annotations to copy constructors with unused parameters
- These classes have no state to copy, hence the parameters are intentionally unused