### PR TITLE
Add missing javadoc for 100% coverage

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
@@ -846,6 +846,11 @@ public final class ExtendedPatternLayout extends AbstractStringLayout {
             return builder;
         }
 
+        /**
+         * Determines if any formatter requires location information.
+         *
+         * @return true if location information is required, false otherwise
+         */
         public boolean requiresLocation() {
             return Arrays.stream(formatters).anyMatch(PatternFormatter::requiresLocation);
         }


### PR DESCRIPTION
## Summary
- Added javadoc for `ExtendedPatternLayout.requiresLocation()` method
- Achieves 100% javadoc coverage for the project