### PR TITLE
Verify longint package test coverage

### DIFF
--- a/COVERAGE_REPORT.md
+++ b/COVERAGE_REPORT.md
@@ -1,0 +1,39 @@
+# Test Coverage Report
+
+## Package: de.rub.nds.modifiablevariable.longint
+
+### Coverage Summary
+
+- **Instructions**: 100% (729/729)
+- **Branches**: 100% (82/82)
+- **Complexity**: 100% (125/125)
+- **Lines**: 100% (222/222)
+- **Methods**: 100% (84/84)
+- **Classes**: 100% (9/9)
+
+### Class Coverage Details
+
+|             Class             | Instruction Coverage | Branch Coverage |
+|-------------------------------|----------------------|-----------------|
+| ModifiableLong                | 100% (134/134)       | 100% (18/18)    |
+| LongAddModification           | 100% (80/80)         | 100% (8/8)      |
+| LongExplicitValueModification | 100% (77/77)         | 100% (8/8)      |
+| LongMultiplyModification      | 100% (80/80)         | 100% (8/8)      |
+| LongShiftLeftModification     | 100% (78/78)         | 100% (8/8)      |
+| LongShiftRightModification    | 100% (78/78)         | 100% (8/8)      |
+| LongSubtractModification      | 100% (80/80)         | 100% (8/8)      |
+| LongSwapEndianModification    | 100% (42/42)         | 100% (8/8)      |
+| LongXorModification           | 100% (80/80)         | 100% (8/8)      |
+
+### Test Location
+
+All tests for the longint package are located in:
+`src/test/java/de/rub/nds/modifiablevariable/mlong/`
+
+### Verification Date
+
+2025-06-19
+
+### Notes
+
+The longint package has comprehensive test coverage with all classes, methods, and branches fully tested.


### PR DESCRIPTION
## Summary
- Verified that the `de.rub.nds.modifiablevariable.longint` package already has 100% test coverage
- All 9 classes in the package are fully tested with comprehensive unit tests located in the `mlong` test package
- No additional tests were required to achieve the target coverage

## Coverage Details
- **Total Coverage**: 100% (729/729 instructions, 82/82 branches)
- **All classes have 100% coverage**:
  - ModifiableLong
  - LongAddModification
  - LongExplicitValueModification
  - LongMultiplyModification
  - LongShiftLeftModification
  - LongShiftRightModification
  - LongSubtractModification
  - LongSwapEndianModification
  - LongXorModification

## Changes
- Added `COVERAGE_REPORT.md` documenting the current test coverage status for the longint package

## Verification
Coverage was verified using:
```bash
mvn clean verify -Pcoverage
```