### PR TITLE
Fix reversed assertEquals parameter order in Long modification tests

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongAddModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongAddModificationTest.java
@@ -87,7 +87,7 @@ public class LongAddModificationTest {
     public void testConstructors() {
         LongAddModification constructor = new LongAddModification(5L);
         assertNotNull(constructor);
-        assertEquals(constructor.getSummand(), 5);
+        assertEquals(5L, constructor.getSummand());
 
         // Test copy constructor
         LongAddModification copy = new LongAddModification(modification);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModificationTest.java
@@ -91,7 +91,7 @@ public class LongExplicitValueModificationTest {
         // Test default constructor
         LongExplicitValueModification constructor = new LongExplicitValueModification(5L);
         assertNotNull(constructor);
-        assertEquals(constructor.getExplicitValue(), 5);
+        assertEquals(5L, constructor.getExplicitValue());
 
         // Test copy constructor
         LongExplicitValueModification copy = new LongExplicitValueModification(modification);


### PR DESCRIPTION
## Summary
- Fixed incorrect parameter order in assertEquals calls in Long modification tests
- Ensures the expected value is the first parameter and actual value is the second parameter, following JUnit conventions

## Changes
- Fixed reversed assertEquals calls in:
  - `src/test/java/de/rub/nds/modifiablevariable/mlong/LongAddModificationTest.java`
  - `src/test/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModificationTest.java`
- Added 'L' suffix to numeric literals to ensure proper Long type matching

## Related Issue
Related to tls-attacker/TLS-Attacker-Development#1321

## Test Plan
- [x] All existing tests still pass
- [x] No functional changes, only parameter order corrections in test assertions
- [x] Code formatting applied via `mvn spotless:apply`