### PR TITLE
Reintegrate AssertionValidation for ModifiableVariableProperty constraints

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariable.java
@@ -8,6 +8,8 @@
 package de.rub.nds.modifiablevariable;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import de.rub.nds.modifiablevariable.validation.ModifiableVariableValidator;
+import de.rub.nds.modifiablevariable.validation.ValidationResult;
 import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.LinkedList;
@@ -188,6 +190,33 @@ public abstract class ModifiableVariable<E> implements Serializable {
      */
     public boolean containsAssertion() {
         return assertEquals != null;
+    }
+
+    /**
+     * Validates this variable against the constraints defined in a ModifiableVariableProperty
+     * annotation.
+     *
+     * <p>This method checks if the current value satisfies the constraints specified in the
+     * property annotation, such as minimum and maximum length requirements.
+     *
+     * @param property The ModifiableVariableProperty annotation containing constraints
+     * @return A ValidationResult indicating whether validation passed or failed
+     */
+    public ValidationResult validateProperty(ModifiableVariableProperty property) {
+        return ModifiableVariableValidator.validateVariable(this, property);
+    }
+
+    /**
+     * Validates this variable against the constraints defined in a ModifiableVariableProperty
+     * annotation, with field context for better error messages.
+     *
+     * @param property The ModifiableVariableProperty annotation containing constraints
+     * @param fieldName The name of the field being validated
+     * @return A ValidationResult indicating whether validation passed or failed
+     */
+    public ValidationResult validateProperty(
+            ModifiableVariableProperty property, String fieldName) {
+        return ModifiableVariableValidator.validateVariable(this, property, fieldName);
     }
 
     /**

--- a/src/main/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableValidator.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableValidator.java
@@ -1,0 +1,267 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import de.rub.nds.modifiablevariable.ModifiableVariable;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import de.rub.nds.modifiablevariable.util.ModifiableVariableAnalyzer;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validator for ModifiableVariable instances that enforces constraints defined by
+ * ModifiableVariableProperty annotations.
+ *
+ * <p>This class provides static methods to validate individual ModifiableVariable instances against
+ * their property constraints, as well as validate all annotated fields within an object.
+ */
+public class ModifiableVariableValidator {
+
+    /** Private constructor to prevent instantiation */
+    private ModifiableVariableValidator() {}
+
+    /**
+     * Validates a ModifiableVariable against the constraints defined in its
+     * ModifiableVariableProperty annotation.
+     *
+     * @param variable The ModifiableVariable to validate
+     * @param property The property annotation containing constraints
+     * @return A ValidationResult indicating success or failure
+     */
+    public static ValidationResult validateVariable(
+            ModifiableVariable<?> variable, ModifiableVariableProperty property) {
+        if (variable == null || property == null) {
+            return ValidationResult.success();
+        }
+
+        List<String> errors = new ArrayList<>();
+
+        // Validate length constraints for applicable types
+        if (variable instanceof ModifiableByteArray) {
+            validateByteArrayLength((ModifiableByteArray) variable, property, errors);
+        } else if (variable instanceof ModifiableString) {
+            validateStringLength((ModifiableString) variable, property, errors);
+        }
+
+        return errors.isEmpty() ? ValidationResult.success() : ValidationResult.failure(errors);
+    }
+
+    /**
+     * Validates a ModifiableVariable with a field context.
+     *
+     * @param variable The ModifiableVariable to validate
+     * @param property The property annotation containing constraints
+     * @param fieldName The name of the field being validated
+     * @return A ValidationResult indicating success or failure
+     */
+    public static ValidationResult validateVariable(
+            ModifiableVariable<?> variable, ModifiableVariableProperty property, String fieldName) {
+        if (variable == null || property == null) {
+            return ValidationResult.success(fieldName);
+        }
+
+        List<String> errors = new ArrayList<>();
+
+        // Validate length constraints for applicable types
+        if (variable instanceof ModifiableByteArray) {
+            validateByteArrayLength((ModifiableByteArray) variable, property, errors);
+        } else if (variable instanceof ModifiableString) {
+            validateStringLength((ModifiableString) variable, property, errors);
+        }
+
+        return errors.isEmpty()
+                ? ValidationResult.success(fieldName)
+                : ValidationResult.failure(fieldName, errors);
+    }
+
+    /**
+     * Validates all ModifiableVariable fields in an object that have ModifiableVariableProperty
+     * annotations.
+     *
+     * @param object The object containing ModifiableVariable fields to validate
+     * @return A combined ValidationResult for all annotated fields
+     */
+    public static ValidationResult validateObject(Object object) {
+        if (object == null) {
+            return ValidationResult.success();
+        }
+
+        List<ValidationResult> results = new ArrayList<>();
+        List<Field> annotatedFields =
+                ModifiableVariableAnalyzer.getAnnotatedFields(object.getClass());
+
+        for (Field field : annotatedFields) {
+            try {
+                field.setAccessible(true);
+                Object value = field.get(object);
+
+                if (value instanceof ModifiableVariable<?>) {
+                    ModifiableVariableProperty property =
+                            field.getAnnotation(ModifiableVariableProperty.class);
+                    ValidationResult result =
+                            validateVariable(
+                                    (ModifiableVariable<?>) value, property, field.getName());
+                    results.add(result);
+                }
+            } catch (IllegalAccessException e) {
+                results.add(
+                        ValidationResult.failure(
+                                field.getName(), "Failed to access field: " + e.getMessage()));
+            }
+        }
+
+        return ValidationResult.combine(results.toArray(new ValidationResult[0]));
+    }
+
+    /**
+     * Validates length constraints for a ModifiableByteArray.
+     *
+     * @param byteArray The byte array to validate
+     * @param property The property annotation containing constraints
+     * @param errors List to accumulate error messages
+     */
+    private static void validateByteArrayLength(
+            ModifiableByteArray byteArray,
+            ModifiableVariableProperty property,
+            List<String> errors) {
+        byte[] value = byteArray.getValue();
+        if (value == null) {
+            return; // Null values are considered valid unless explicitly constrained
+        }
+
+        int length = value.length;
+
+        if (property.minLength() != -1 && length < property.minLength()) {
+            errors.add(
+                    String.format(
+                            "Byte array length %d is less than minimum required length %d",
+                            length, property.minLength()));
+        }
+
+        if (property.maxLength() != -1 && length > property.maxLength()) {
+            errors.add(
+                    String.format(
+                            "Byte array length %d exceeds maximum allowed length %d",
+                            length, property.maxLength()));
+        }
+    }
+
+    /**
+     * Validates length constraints for a ModifiableString.
+     *
+     * @param modString The string to validate
+     * @param property The property annotation containing constraints
+     * @param errors List to accumulate error messages
+     */
+    private static void validateStringLength(
+            ModifiableString modString, ModifiableVariableProperty property, List<String> errors) {
+        String value = modString.getValue();
+        if (value == null) {
+            return; // Null values are considered valid unless explicitly constrained
+        }
+
+        // For strings, we validate based on UTF-8 byte length by default
+        int byteLength = value.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+
+        if (property.minLength() != -1 && byteLength < property.minLength()) {
+            errors.add(
+                    String.format(
+                            "String byte length %d is less than minimum required length %d",
+                            byteLength, property.minLength()));
+        }
+
+        if (property.maxLength() != -1 && byteLength > property.maxLength()) {
+            errors.add(
+                    String.format(
+                            "String byte length %d exceeds maximum allowed length %d",
+                            byteLength, property.maxLength()));
+        }
+    }
+
+    /**
+     * Creates a validator context for fluent validation with custom rules.
+     *
+     * @param variable The ModifiableVariable to validate
+     * @return A new ValidatorContext for the variable
+     */
+    public static ValidatorContext validate(ModifiableVariable<?> variable) {
+        return new ValidatorContext(variable);
+    }
+
+    /** Context class for building custom validation rules in a fluent manner. */
+    public static class ValidatorContext {
+        private final ModifiableVariable<?> variable;
+        private final List<String> errors = new ArrayList<>();
+        private String fieldName;
+
+        private ValidatorContext(ModifiableVariable<?> variable) {
+            this.variable = variable;
+        }
+
+        /**
+         * Sets the field name for error messages.
+         *
+         * @param fieldName The field name
+         * @return This context for chaining
+         */
+        public ValidatorContext withFieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        /**
+         * Validates against a ModifiableVariableProperty annotation.
+         *
+         * @param property The property annotation
+         * @return This context for chaining
+         */
+        public ValidatorContext againstProperty(ModifiableVariableProperty property) {
+            ValidationResult result =
+                    fieldName != null
+                            ? validateVariable(variable, property, fieldName)
+                            : validateVariable(variable, property);
+
+            if (!result.isValid()) {
+                errors.addAll(result.getErrors());
+            }
+            return this;
+        }
+
+        /**
+         * Adds a custom validation rule.
+         *
+         * @param condition The condition that must be true for validation to pass
+         * @param errorMessage The error message if the condition is false
+         * @return This context for chaining
+         */
+        public ValidatorContext mustSatisfy(boolean condition, String errorMessage) {
+            if (!condition) {
+                errors.add(errorMessage);
+            }
+            return this;
+        }
+
+        /**
+         * Completes the validation and returns the result.
+         *
+         * @return The validation result
+         */
+        public ValidationResult getResult() {
+            return errors.isEmpty()
+                    ? (fieldName != null
+                            ? ValidationResult.success(fieldName)
+                            : ValidationResult.success())
+                    : (fieldName != null
+                            ? ValidationResult.failure(fieldName, errors)
+                            : ValidationResult.failure(errors));
+        }
+    }
+}

--- a/src/main/java/de/rub/nds/modifiablevariable/validation/ValidationResult.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/validation/ValidationResult.java
@@ -1,0 +1,201 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the result of validating a ModifiableVariable against its property constraints.
+ *
+ * <p>This class encapsulates the validation outcome, including whether the validation passed and
+ * any validation errors that occurred. It provides a fluent API for building validation results.
+ */
+public class ValidationResult implements Serializable {
+
+    /** Indicates whether the validation passed */
+    private final boolean valid;
+
+    /** List of validation error messages */
+    private final List<String> errors;
+
+    /** The field name being validated, if available */
+    private final String fieldName;
+
+    /**
+     * Private constructor for creating validation results.
+     *
+     * @param valid Whether the validation passed
+     * @param fieldName The field name being validated
+     * @param errors List of error messages
+     */
+    private ValidationResult(boolean valid, String fieldName, List<String> errors) {
+        this.valid = valid;
+        this.fieldName = fieldName;
+        this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
+    }
+
+    /**
+     * Creates a successful validation result.
+     *
+     * @return A ValidationResult indicating success
+     */
+    public static ValidationResult success() {
+        return new ValidationResult(true, null, Collections.emptyList());
+    }
+
+    /**
+     * Creates a successful validation result for a specific field.
+     *
+     * @param fieldName The name of the field that passed validation
+     * @return A ValidationResult indicating success
+     */
+    public static ValidationResult success(String fieldName) {
+        return new ValidationResult(true, fieldName, Collections.emptyList());
+    }
+
+    /**
+     * Creates a failed validation result with a single error message.
+     *
+     * @param error The error message
+     * @return A ValidationResult indicating failure
+     */
+    public static ValidationResult failure(String error) {
+        return new ValidationResult(false, null, Collections.singletonList(error));
+    }
+
+    /**
+     * Creates a failed validation result for a specific field with a single error message.
+     *
+     * @param fieldName The name of the field that failed validation
+     * @param error The error message
+     * @return A ValidationResult indicating failure
+     */
+    public static ValidationResult failure(String fieldName, String error) {
+        return new ValidationResult(false, fieldName, Collections.singletonList(error));
+    }
+
+    /**
+     * Creates a failed validation result with multiple error messages.
+     *
+     * @param errors List of error messages
+     * @return A ValidationResult indicating failure
+     */
+    public static ValidationResult failure(List<String> errors) {
+        return new ValidationResult(false, null, errors);
+    }
+
+    /**
+     * Creates a failed validation result for a specific field with multiple error messages.
+     *
+     * @param fieldName The name of the field that failed validation
+     * @param errors List of error messages
+     * @return A ValidationResult indicating failure
+     */
+    public static ValidationResult failure(String fieldName, List<String> errors) {
+        return new ValidationResult(false, fieldName, errors);
+    }
+
+    /**
+     * Combines multiple validation results into a single result.
+     *
+     * @param results The validation results to combine
+     * @return A combined ValidationResult
+     */
+    public static ValidationResult combine(ValidationResult... results) {
+        boolean allValid = true;
+        List<String> allErrors = new ArrayList<>();
+
+        for (ValidationResult result : results) {
+            if (!result.isValid()) {
+                allValid = false;
+                allErrors.addAll(result.getErrors());
+            }
+        }
+
+        return new ValidationResult(allValid, null, allErrors);
+    }
+
+    /**
+     * Checks if the validation passed.
+     *
+     * @return true if validation passed, false otherwise
+     */
+    public boolean isValid() {
+        return valid;
+    }
+
+    /**
+     * Gets the list of validation error messages.
+     *
+     * @return An unmodifiable list of error messages
+     */
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    /**
+     * Gets the field name associated with this validation result.
+     *
+     * @return The field name, or null if not specified
+     */
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    /**
+     * Gets a formatted error message combining all errors.
+     *
+     * @return A formatted string containing all error messages
+     */
+    public String getFormattedErrors() {
+        if (errors.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (fieldName != null) {
+            sb.append("Validation failed for field '").append(fieldName).append("': ");
+        } else {
+            sb.append("Validation failed: ");
+        }
+
+        if (errors.size() == 1) {
+            sb.append(errors.get(0));
+        } else {
+            sb.append("\n");
+            for (int i = 0; i < errors.size(); i++) {
+                sb.append("  ").append(i + 1).append(". ").append(errors.get(i));
+                if (i < errors.size() - 1) {
+                    sb.append("\n");
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        if (valid) {
+            return fieldName != null
+                    ? "ValidationResult{valid=true, field='" + fieldName + "'}"
+                    : "ValidationResult{valid=true}";
+        } else {
+            return fieldName != null
+                    ? "ValidationResult{valid=false, field='"
+                            + fieldName
+                            + "', errors="
+                            + errors
+                            + "}"
+                    : "ValidationResult{valid=false, errors=" + errors + "}";
+        }
+    }
+}

--- a/src/test/java/de/rub/nds/modifiablevariable/example/ValidationExample.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/example/ValidationExample.java
@@ -1,0 +1,135 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.example;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableHolder;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Encoding;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Purpose;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import de.rub.nds.modifiablevariable.validation.ValidationResult;
+
+/** Example demonstrating the property validation feature for ModifiableVariables. */
+public class ValidationExample {
+
+    public static void main(String[] args) {
+        // Create a protocol message
+        ProtocolMessage message = new ProtocolMessage();
+        message.initialize();
+
+        // Validate the entire message
+        ValidationResult result = message.validatePropertyAnnotations();
+
+        if (result.isValid()) {
+            System.out.println("Message validation passed!");
+        } else {
+            System.out.println("Message validation failed:");
+            System.out.println(result.getFormattedErrors());
+        }
+
+        // Example of individual field validation
+        ModifiableByteArray sessionKey = new ModifiableByteArray();
+        sessionKey.setOriginalValue(
+                new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+
+        ModifiableVariableProperty keyProperty =
+                new ModifiableVariableProperty() {
+                    @Override
+                    public Purpose purpose() {
+                        return Purpose.KEY_MATERIAL;
+                    }
+
+                    @Override
+                    public Encoding encoding() {
+                        return Encoding.BINARY;
+                    }
+
+                    @Override
+                    public int minLength() {
+                        return 16;
+                    }
+
+                    @Override
+                    public int maxLength() {
+                        return 32;
+                    }
+
+                    @Override
+                    public Class<? extends java.lang.annotation.Annotation> annotationType() {
+                        return ModifiableVariableProperty.class;
+                    }
+                };
+
+        ValidationResult keyResult = sessionKey.validateProperty(keyProperty, "sessionKey");
+        System.out.println(
+                "\nSession key validation: " + (keyResult.isValid() ? "PASSED" : "FAILED"));
+    }
+
+    /** Example protocol message with validation constraints */
+    static class ProtocolMessage extends ModifiableVariableHolder {
+
+        @ModifiableVariableProperty(purpose = Purpose.CONSTANT, minLength = 2, maxLength = 2)
+        private ModifiableByteArray protocolVersion;
+
+        @ModifiableVariableProperty(
+                purpose = Purpose.LENGTH,
+                encoding = Encoding.UNSIGNED_BIG_ENDIAN,
+                minLength = 2,
+                maxLength = 2)
+        private ModifiableByteArray messageLength;
+
+        @ModifiableVariableProperty(purpose = Purpose.RANDOM, minLength = 32, maxLength = 32)
+        private ModifiableByteArray nonce;
+
+        @ModifiableVariableProperty(
+                purpose = Purpose.IDENTIFIER,
+                encoding = Encoding.UTF8,
+                minLength = 1,
+                maxLength = 255)
+        private ModifiableString clientId;
+
+        @ModifiableVariableProperty(
+                purpose = Purpose.TIMESTAMP,
+                encoding = Encoding.UNSIGNED_BIG_ENDIAN,
+                minLength = 8,
+                maxLength = 8)
+        private ModifiableByteArray timestamp;
+
+        public void initialize() {
+            protocolVersion = new ModifiableByteArray();
+            protocolVersion.setOriginalValue(new byte[] {0x03, 0x03}); // TLS 1.2
+
+            messageLength = new ModifiableByteArray();
+            messageLength.setOriginalValue(new byte[] {0x00, 0x64}); // 100 bytes
+
+            nonce = new ModifiableByteArray();
+            byte[] randomNonce = new byte[32];
+            for (int i = 0; i < 32; i++) {
+                randomNonce[i] = (byte) (i * 7);
+            }
+            nonce.setOriginalValue(randomNonce);
+
+            clientId = new ModifiableString();
+            clientId.setOriginalValue("client-12345");
+
+            timestamp = new ModifiableByteArray();
+            long currentTime = System.currentTimeMillis();
+            timestamp.setOriginalValue(longToBytes(currentTime));
+        }
+
+        private byte[] longToBytes(long value) {
+            byte[] result = new byte[8];
+            for (int i = 7; i >= 0; i--) {
+                result[i] = (byte) (value & 0xFF);
+                value >>= 8;
+            }
+            return result;
+        }
+    }
+}

--- a/src/test/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableHolderValidationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableHolderValidationTest.java
@@ -1,0 +1,234 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.modifiablevariable.HoldsModifiableVariable;
+import de.rub.nds.modifiablevariable.ModifiableVariableHolder;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Encoding;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Purpose;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import org.junit.jupiter.api.Test;
+
+/** Tests for validation functionality in ModifiableVariableHolder. */
+public class ModifiableVariableHolderValidationTest {
+
+    @Test
+    public void testValidatePropertyAnnotations() {
+        TestMessage message = new TestMessage();
+        message.initializeValid();
+
+        ValidationResult result = message.validatePropertyAnnotations();
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testValidatePropertyAnnotationsWithErrors() {
+        TestMessage message = new TestMessage();
+        message.initializeInvalid();
+
+        ValidationResult result = message.validatePropertyAnnotations();
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testValidateAssertions() {
+        TestMessage message = new TestMessage();
+        message.initializeValid();
+
+        // Set assertions that should pass
+        message.messageType.setAssertEquals(new byte[] {0x01});
+        message.payload.setAssertEquals("Hello, World!".getBytes());
+
+        assertTrue(message.validateAssertions());
+    }
+
+    @Test
+    public void testValidateAssertionsFailed() {
+        TestMessage message = new TestMessage();
+        message.initializeValid();
+
+        // Set assertion that should fail
+        message.messageType.setAssertEquals(new byte[] {0x02}); // Actual is 0x01
+
+        assertFalse(message.validateAssertions());
+    }
+
+    @Test
+    public void testValidateNestedHolders() {
+        NestedMessage parent = new NestedMessage();
+        parent.initializeValid();
+
+        // Test property validation
+        ValidationResult propResult = parent.validatePropertyAnnotations();
+        assertTrue(propResult.isValid());
+
+        // Test assertion validation
+        parent.header.headerType.setAssertEquals(new byte[] {(byte) 0xAA});
+        parent.content.contentData.setAssertEquals("Content".getBytes());
+
+        assertTrue(parent.validateAssertions());
+
+        // Make nested assertion fail
+        parent.content.contentData.setAssertEquals("Wrong".getBytes());
+        assertFalse(parent.validateAssertions());
+    }
+
+    @Test
+    public void testValidateWithNoAnnotations() {
+        NoAnnotationsMessage message = new NoAnnotationsMessage();
+        message.initialize();
+
+        // Should pass since there are no property annotations to validate
+        ValidationResult result = message.validatePropertyAnnotations();
+        assertTrue(result.isValid());
+
+        // Assertion validation should still work
+        message.data.setAssertEquals("test".getBytes());
+        assertTrue(message.validateAssertions());
+    }
+
+    @Test
+    public void testValidateMixedFields() {
+        MixedFieldsMessage message = new MixedFieldsMessage();
+        message.initialize();
+
+        ValidationResult result = message.validatePropertyAnnotations();
+        // Should validate only annotated fields
+        assertFalse(result.isValid()); // shortData is too short
+        assertEquals(1, result.getErrors().size());
+    }
+
+    // Test classes
+    private static class TestMessage extends ModifiableVariableHolder {
+        @ModifiableVariableProperty(
+                purpose = Purpose.LENGTH,
+                encoding = Encoding.UNSIGNED_BIG_ENDIAN,
+                minLength = 2,
+                maxLength = 2)
+        private ModifiableByteArray messageLength;
+
+        @ModifiableVariableProperty(purpose = Purpose.CONSTANT, minLength = 1, maxLength = 1)
+        private ModifiableByteArray messageType;
+
+        @ModifiableVariableProperty(
+                purpose = Purpose.PLAINTEXT,
+                encoding = Encoding.UTF8,
+                maxLength = 100)
+        private ModifiableByteArray payload;
+
+        void initializeValid() {
+            messageLength = new ModifiableByteArray();
+            messageLength.setOriginalValue(new byte[] {0x00, 0x0D}); // Length = 13
+
+            messageType = new ModifiableByteArray();
+            messageType.setOriginalValue(new byte[] {0x01});
+
+            payload = new ModifiableByteArray();
+            payload.setOriginalValue("Hello, World!".getBytes());
+        }
+
+        void initializeInvalid() {
+            messageLength = new ModifiableByteArray();
+            messageLength.setOriginalValue(new byte[] {0x00}); // Too short
+
+            messageType = new ModifiableByteArray();
+            messageType.setOriginalValue(new byte[] {0x01, 0x02}); // Too long
+
+            payload = new ModifiableByteArray();
+            payload.setOriginalValue(new byte[101]); // Too long
+        }
+    }
+
+    private static class NestedMessage extends ModifiableVariableHolder {
+        @HoldsModifiableVariable private MessageHeader header;
+
+        @HoldsModifiableVariable private MessageContent content;
+
+        void initializeValid() {
+            header = new MessageHeader();
+            header.initialize();
+
+            content = new MessageContent();
+            content.initialize();
+        }
+    }
+
+    private static class MessageHeader extends ModifiableVariableHolder {
+        @ModifiableVariableProperty(minLength = 1, maxLength = 1)
+        private ModifiableByteArray headerType;
+
+        @ModifiableVariableProperty(minLength = 4, maxLength = 4)
+        private ModifiableByteArray headerVersion;
+
+        void initialize() {
+            headerType = new ModifiableByteArray();
+            headerType.setOriginalValue(new byte[] {(byte) 0xAA});
+
+            headerVersion = new ModifiableByteArray();
+            headerVersion.setOriginalValue(new byte[] {0x01, 0x00, 0x00, 0x00});
+        }
+    }
+
+    private static class MessageContent extends ModifiableVariableHolder {
+        @ModifiableVariableProperty(purpose = Purpose.PLAINTEXT, minLength = 1, maxLength = 1000)
+        private ModifiableByteArray contentData;
+
+        void initialize() {
+            contentData = new ModifiableByteArray();
+            contentData.setOriginalValue("Content".getBytes());
+        }
+    }
+
+    private static class NoAnnotationsMessage extends ModifiableVariableHolder {
+        private ModifiableByteArray data;
+        private ModifiableInteger count;
+
+        void initialize() {
+            data = new ModifiableByteArray();
+            data.setOriginalValue("test".getBytes());
+
+            count = new ModifiableInteger();
+            count.setOriginalValue(42);
+        }
+    }
+
+    private static class MixedFieldsMessage extends ModifiableVariableHolder {
+        // Annotated field
+        @ModifiableVariableProperty(minLength = 4, maxLength = 8)
+        private ModifiableByteArray shortData;
+
+        // Non-annotated field
+        private ModifiableByteArray longData;
+
+        // Annotated field
+        @ModifiableVariableProperty(
+                purpose = Purpose.IDENTIFIER,
+                encoding = Encoding.UTF8,
+                minLength = 3,
+                maxLength = 20)
+        private ModifiableString identifier;
+
+        void initialize() {
+            shortData = new ModifiableByteArray();
+            shortData.setOriginalValue(new byte[] {1, 2}); // Too short
+
+            longData = new ModifiableByteArray();
+            longData.setOriginalValue(new byte[100]); // No constraints
+
+            identifier = new ModifiableString();
+            identifier.setOriginalValue("ID123"); // Valid
+        }
+    }
+}

--- a/src/test/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableValidatorTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/validation/ModifiableVariableValidatorTest.java
@@ -1,0 +1,325 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Encoding;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Purpose;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import java.lang.annotation.Annotation;
+import org.junit.jupiter.api.Test;
+
+public class ModifiableVariableValidatorTest {
+
+    // Helper method to create ModifiableVariableProperty annotations
+    private static ModifiableVariableProperty createProperty(
+            Purpose purpose, Encoding encoding, int minLength, int maxLength) {
+        return new ModifiableVariableProperty() {
+            @Override
+            public Purpose purpose() {
+                return purpose;
+            }
+
+            @Override
+            public Encoding encoding() {
+                return encoding;
+            }
+
+            @Override
+            public int minLength() {
+                return minLength;
+            }
+
+            @Override
+            public int maxLength() {
+                return maxLength;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ModifiableVariableProperty.class;
+            }
+        };
+    }
+
+    @Test
+    public void testValidateByteArrayWithinBounds() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2, 3, 4});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testValidateByteArrayBelowMinLength() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+        assertTrue(result.getErrors().get(0).contains("less than minimum required length"));
+    }
+
+    @Test
+    public void testValidateByteArrayAboveMaxLength() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2, 3, 4, 5, 6});
+
+        ModifiableVariableProperty property = createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 5);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+        assertTrue(result.getErrors().get(0).contains("exceeds maximum allowed length"));
+    }
+
+    @Test
+    public void testValidateByteArrayWithBothViolations() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1});
+
+        // Create property where value violates both min and max (min > max for testing)
+        ModifiableVariableProperty property = createProperty(Purpose.RANDOM, Encoding.BINARY, 5, 0);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertFalse(result.isValid());
+        assertEquals(2, result.getErrors().size());
+    }
+
+    @Test
+    public void testValidateByteArrayNoConstraints() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2, 3});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, -1, -1);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testValidateByteArrayNullValue() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        // No original value set
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, property);
+        assertTrue(result.isValid()); // Null values are considered valid
+    }
+
+    @Test
+    public void testValidateStringWithinBounds() {
+        ModifiableString modString = new ModifiableString();
+        modString.setOriginalValue("test");
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.PLAINTEXT, Encoding.UTF8, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(modString, property);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testValidateStringBelowMinLength() {
+        ModifiableString modString = new ModifiableString();
+        modString.setOriginalValue("a");
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.PLAINTEXT, Encoding.UTF8, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(modString, property);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("less than minimum required length"));
+    }
+
+    @Test
+    public void testValidateStringAboveMaxLength() {
+        ModifiableString modString = new ModifiableString();
+        modString.setOriginalValue("This is a very long string");
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.PLAINTEXT, Encoding.UTF8, 2, 10);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(modString, property);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("exceeds maximum allowed length"));
+    }
+
+    @Test
+    public void testValidateStringUtf8ByteLength() {
+        ModifiableString modString = new ModifiableString();
+        // Unicode character that takes 3 bytes in UTF-8
+        modString.setOriginalValue("€"); // Euro sign is 3 bytes in UTF-8
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.PLAINTEXT, Encoding.UTF8, 1, 2);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(modString, property);
+        assertFalse(result.isValid()); // 3 bytes exceeds max of 2
+    }
+
+    @Test
+    public void testValidateWithFieldName() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 10);
+
+        ValidationResult result =
+                ModifiableVariableValidator.validateVariable(byteArray, property, "testField");
+
+        assertFalse(result.isValid());
+        assertEquals("testField", result.getFieldName());
+    }
+
+    @Test
+    public void testValidateNonConstrainedType() {
+        // Test with a type that doesn't have length constraints (e.g., ModifiableInteger)
+        ModifiableInteger modInt = new ModifiableInteger();
+        modInt.setOriginalValue(42);
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.COUNT, Encoding.UNSIGNED_BIG_ENDIAN, 1, 100);
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(modInt, property);
+        assertTrue(result.isValid()); // No length validation for integers
+    }
+
+    @Test
+    public void testValidateNullVariable() {
+        ValidationResult result =
+                ModifiableVariableValidator.validateVariable(
+                        null, createProperty(Purpose.RANDOM, Encoding.BINARY, 1, 10));
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testValidateNullProperty() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2, 3});
+
+        ValidationResult result = ModifiableVariableValidator.validateVariable(byteArray, null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testValidatorContextFluentApi() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2, 3});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 2, 10);
+
+        ValidationResult result =
+                ModifiableVariableValidator.validate(byteArray)
+                        .withFieldName("testField")
+                        .againstProperty(property)
+                        .mustSatisfy(byteArray.getValue()[0] == 1, "First byte must be 1")
+                        .mustSatisfy(byteArray.getValue().length % 2 == 1, "Length must be odd")
+                        .getResult();
+
+        assertTrue(result.isValid());
+        assertEquals("testField", result.getFieldName());
+    }
+
+    @Test
+    public void testValidatorContextWithFailures() {
+        ModifiableByteArray byteArray = new ModifiableByteArray();
+        byteArray.setOriginalValue(new byte[] {1, 2});
+
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 3, 10);
+
+        ValidationResult result =
+                ModifiableVariableValidator.validate(byteArray)
+                        .withFieldName("testField")
+                        .againstProperty(property)
+                        .mustSatisfy(false, "Custom validation failed")
+                        .getResult();
+
+        assertFalse(result.isValid());
+        assertEquals(2, result.getErrors().size()); // Length violation + custom failure
+    }
+
+    @Test
+    public void testValidateObjectWithAnnotatedFields() {
+        TestClassWithAnnotations testObject = new TestClassWithAnnotations();
+
+        ValidationResult result = ModifiableVariableValidator.validateObject(testObject);
+
+        // The validField should pass, invalidField should fail
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testValidateObjectAllValid() {
+        TestClassAllValid testObject = new TestClassAllValid();
+
+        ValidationResult result = ModifiableVariableValidator.validateObject(testObject);
+
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testValidateObjectNull() {
+        ValidationResult result = ModifiableVariableValidator.validateObject(null);
+        assertTrue(result.isValid());
+    }
+
+    // Test helper classes
+    private static class TestClassWithAnnotations {
+        @ModifiableVariableProperty(minLength = 2, maxLength = 10)
+        private ModifiableByteArray validField;
+
+        @ModifiableVariableProperty(minLength = 5, maxLength = 10)
+        private ModifiableByteArray invalidField;
+
+        public TestClassWithAnnotations() {
+            validField = new ModifiableByteArray();
+            validField.setOriginalValue(new byte[] {1, 2, 3});
+
+            invalidField = new ModifiableByteArray();
+            invalidField.setOriginalValue(new byte[] {1}); // Too short
+        }
+    }
+
+    private static class TestClassAllValid {
+        @ModifiableVariableProperty(minLength = 1, maxLength = 10)
+        private ModifiableByteArray field1;
+
+        @ModifiableVariableProperty(minLength = 2, maxLength = 20)
+        private ModifiableString field2;
+
+        public TestClassAllValid() {
+            field1 = new ModifiableByteArray();
+            field1.setOriginalValue(new byte[] {1, 2, 3});
+
+            field2 = new ModifiableString();
+            field2.setOriginalValue("test");
+        }
+    }
+}

--- a/src/test/java/de/rub/nds/modifiablevariable/validation/PropertyValidationIntegrationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/validation/PropertyValidationIntegrationTest.java
@@ -1,0 +1,254 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Encoding;
+import de.rub.nds.modifiablevariable.ModifiableVariableProperty.Purpose;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayDeleteModification;
+import de.rub.nds.modifiablevariable.bytearray.ByteArrayPrependValueModification;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import de.rub.nds.modifiablevariable.string.StringAppendValueModification;
+import java.lang.annotation.Annotation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests demonstrating the property validation functionality in real-world scenarios.
+ */
+public class PropertyValidationIntegrationTest {
+
+    // Helper to create property annotations
+    private static ModifiableVariableProperty createProperty(
+            Purpose purpose, Encoding encoding, int minLength, int maxLength) {
+        return new ModifiableVariableProperty() {
+            @Override
+            public Purpose purpose() {
+                return purpose;
+            }
+
+            @Override
+            public Encoding encoding() {
+                return encoding;
+            }
+
+            @Override
+            public int minLength() {
+                return minLength;
+            }
+
+            @Override
+            public int maxLength() {
+                return maxLength;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ModifiableVariableProperty.class;
+            }
+        };
+    }
+
+    @Test
+    public void testValidatePropertyMethodOnModifiableVariable() {
+        // Test the validateProperty method added to ModifiableVariable
+        ModifiableByteArray nonce = new ModifiableByteArray();
+        nonce.setOriginalValue(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+
+        // Property requiring exactly 8 bytes for a nonce
+        ModifiableVariableProperty property = createProperty(Purpose.RANDOM, Encoding.BINARY, 8, 8);
+
+        ValidationResult result = nonce.validateProperty(property);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testValidatePropertyWithFieldName() {
+        ModifiableString sessionId = new ModifiableString();
+        sessionId.setOriginalValue("ABC123");
+
+        // Session ID must be between 6 and 32 characters
+        ModifiableVariableProperty property =
+                createProperty(Purpose.IDENTIFIER, Encoding.UTF8, 6, 32);
+
+        ValidationResult result = sessionId.validateProperty(property, "sessionId");
+        assertTrue(result.isValid());
+        assertEquals("sessionId", result.getFieldName());
+    }
+
+    @Test
+    public void testValidationWithModifications() {
+        // Create a byte array with valid initial length
+        ModifiableByteArray signature = new ModifiableByteArray();
+        signature.setOriginalValue(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+
+        // Signature must be between 6 and 10 bytes
+        ModifiableVariableProperty property =
+                createProperty(Purpose.SIGNATURE, Encoding.ASN1_DER, 6, 10);
+
+        // Initially valid
+        assertTrue(signature.validateProperty(property).isValid());
+
+        // Add modification that makes it too short
+        signature.setModifications(new ByteArrayDeleteModification(0, 5));
+        ValidationResult result = signature.validateProperty(property);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("less than minimum"));
+
+        // Add modification that makes it too long
+        signature.clearModifications();
+        signature.setModifications(new ByteArrayPrependValueModification(new byte[] {0, 0, 0, 0}));
+        result = signature.validateProperty(property);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("exceeds maximum"));
+    }
+
+    @Test
+    public void testRealWorldScenario_TlsRandom() {
+        // TLS Random structure: 4 bytes timestamp + 28 bytes random
+        ModifiableByteArray tlsRandom = new ModifiableByteArray();
+        byte[] randomValue = new byte[32];
+        randomValue[0] = (byte) 0x5A; // Timestamp bytes
+        randomValue[1] = (byte) 0x6B;
+        randomValue[2] = (byte) 0x7C;
+        randomValue[3] = (byte) 0x8D;
+        // Rest is random
+        for (int i = 4; i < 32; i++) {
+            randomValue[i] = (byte) i;
+        }
+        tlsRandom.setOriginalValue(randomValue);
+
+        // TLS Random must be exactly 32 bytes
+        ModifiableVariableProperty property =
+                createProperty(Purpose.RANDOM, Encoding.BINARY, 32, 32);
+
+        ValidationResult result = tlsRandom.validateProperty(property, "ClientRandom");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testRealWorldScenario_Certificate() {
+        // Simulate a certificate field
+        ModifiableByteArray certificate = new ModifiableByteArray();
+        // DER-encoded certificate (simplified)
+        certificate.setOriginalValue(new byte[300]); // Typical cert size
+
+        // Certificates typically range from 200 to 2048 bytes
+        ModifiableVariableProperty property =
+                createProperty(Purpose.CERTIFICATE, Encoding.X509, 200, 2048);
+
+        ValidationResult result = certificate.validateProperty(property, "ServerCertificate");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testRealWorldScenario_Padding() {
+        // Simulate PKCS padding
+        ModifiableByteArray padding = new ModifiableByteArray();
+        padding.setOriginalValue(new byte[] {4, 4, 4, 4}); // PKCS padding with value 4
+
+        // Padding can be 1 to 255 bytes
+        ModifiableVariableProperty property =
+                createProperty(Purpose.PADDING, Encoding.BINARY, 1, 255);
+
+        ValidationResult result = padding.validateProperty(property);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testComplexValidationScenario() {
+        // Test with multiple validation criteria
+        ModifiableString username = new ModifiableString();
+        username.setOriginalValue("alice");
+
+        // Username requirements: 3-20 characters
+        ModifiableVariableProperty property =
+                createProperty(Purpose.IDENTIFIER, Encoding.UTF8, 3, 20);
+
+        // Custom validation with additional rules
+        ValidationResult result =
+                ModifiableVariableValidator.validate(username)
+                        .withFieldName("username")
+                        .againstProperty(property)
+                        .mustSatisfy(
+                                !username.getValue().contains(" "),
+                                "Username cannot contain spaces")
+                        .mustSatisfy(
+                                username.getValue().matches("^[a-zA-Z0-9]+$"),
+                                "Username must be alphanumeric")
+                        .getResult();
+
+        assertTrue(result.isValid());
+
+        // Test with invalid username
+        username.setModifications(new StringAppendValueModification("@#$"));
+        result =
+                ModifiableVariableValidator.validate(username)
+                        .withFieldName("username")
+                        .againstProperty(property)
+                        .mustSatisfy(
+                                !username.getValue().contains(" "),
+                                "Username cannot contain spaces")
+                        .mustSatisfy(
+                                username.getValue().matches("^[a-zA-Z0-9]+$"),
+                                "Username must be alphanumeric")
+                        .getResult();
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().stream().anyMatch(e -> e.contains("must be alphanumeric")));
+    }
+
+    @Test
+    public void testValidationInProtocolContext() {
+        // Simulate a protocol message with multiple fields
+        class ProtocolMessage {
+            @ModifiableVariableProperty(
+                    purpose = Purpose.LENGTH,
+                    encoding = Encoding.UNSIGNED_BIG_ENDIAN,
+                    minLength = 2,
+                    maxLength = 2)
+            public ModifiableByteArray messageLength;
+
+            @ModifiableVariableProperty(
+                    purpose = Purpose.CONSTANT,
+                    encoding = Encoding.BINARY,
+                    minLength = 1,
+                    maxLength = 1)
+            public ModifiableByteArray messageType;
+
+            @ModifiableVariableProperty(
+                    purpose = Purpose.PLAINTEXT,
+                    encoding = Encoding.UTF8,
+                    minLength = 0,
+                    maxLength = 65535)
+            public ModifiableByteArray payload;
+
+            public ProtocolMessage() {
+                messageLength = new ModifiableByteArray();
+                messageLength.setOriginalValue(new byte[] {0x00, 0x10}); // Length = 16
+
+                messageType = new ModifiableByteArray();
+                messageType.setOriginalValue(new byte[] {0x01}); // Type = 1
+
+                payload = new ModifiableByteArray();
+                payload.setOriginalValue("Hello, World!".getBytes());
+            }
+        }
+
+        ProtocolMessage message = new ProtocolMessage();
+        ValidationResult result = ModifiableVariableValidator.validateObject(message);
+        assertTrue(result.isValid());
+
+        // Make message invalid by changing length field
+        message.messageLength.setOriginalValue(new byte[] {0x00}); // Only 1 byte
+        result = ModifiableVariableValidator.validateObject(message);
+        assertFalse(result.isValid());
+    }
+}

--- a/src/test/java/de/rub/nds/modifiablevariable/validation/ValidationResultTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/validation/ValidationResultTest.java
@@ -1,0 +1,196 @@
+/*
+ * ModifiableVariable - A Variable Concept for Runtime Modifications
+ *
+ * Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.modifiablevariable.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ValidationResultTest {
+
+    @Test
+    public void testSuccessCreation() {
+        ValidationResult result = ValidationResult.success();
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+        assertNull(result.getFieldName());
+    }
+
+    @Test
+    public void testSuccessWithFieldName() {
+        ValidationResult result = ValidationResult.success("testField");
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals("testField", result.getFieldName());
+    }
+
+    @Test
+    public void testFailureWithSingleError() {
+        String error = "Validation failed";
+        ValidationResult result = ValidationResult.failure(error);
+
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+        assertEquals(error, result.getErrors().get(0));
+        assertNull(result.getFieldName());
+    }
+
+    @Test
+    public void testFailureWithFieldNameAndError() {
+        String fieldName = "testField";
+        String error = "Field validation failed";
+        ValidationResult result = ValidationResult.failure(fieldName, error);
+
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+        assertEquals(error, result.getErrors().get(0));
+        assertEquals(fieldName, result.getFieldName());
+    }
+
+    @Test
+    public void testFailureWithMultipleErrors() {
+        List<String> errors = Arrays.asList("Error 1", "Error 2", "Error 3");
+        ValidationResult result = ValidationResult.failure(errors);
+
+        assertFalse(result.isValid());
+        assertEquals(3, result.getErrors().size());
+        assertEquals(errors, result.getErrors());
+        assertNull(result.getFieldName());
+    }
+
+    @Test
+    public void testFailureWithFieldNameAndMultipleErrors() {
+        String fieldName = "testField";
+        List<String> errors = Arrays.asList("Error 1", "Error 2");
+        ValidationResult result = ValidationResult.failure(fieldName, errors);
+
+        assertFalse(result.isValid());
+        assertEquals(2, result.getErrors().size());
+        assertEquals(errors, result.getErrors());
+        assertEquals(fieldName, result.getFieldName());
+    }
+
+    @Test
+    public void testCombineAllSuccessful() {
+        ValidationResult result1 = ValidationResult.success();
+        ValidationResult result2 = ValidationResult.success("field1");
+        ValidationResult result3 = ValidationResult.success("field2");
+
+        ValidationResult combined = ValidationResult.combine(result1, result2, result3);
+
+        assertTrue(combined.isValid());
+        assertTrue(combined.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testCombineMixedResults() {
+        ValidationResult success1 = ValidationResult.success();
+        ValidationResult failure1 = ValidationResult.failure("Error 1");
+        ValidationResult success2 = ValidationResult.success("field1");
+        ValidationResult failure2 =
+                ValidationResult.failure("field2", Arrays.asList("Error 2", "Error 3"));
+
+        ValidationResult combined =
+                ValidationResult.combine(success1, failure1, success2, failure2);
+
+        assertFalse(combined.isValid());
+        assertEquals(3, combined.getErrors().size());
+        assertTrue(combined.getErrors().contains("Error 1"));
+        assertTrue(combined.getErrors().contains("Error 2"));
+        assertTrue(combined.getErrors().contains("Error 3"));
+    }
+
+    @Test
+    public void testCombineAllFailures() {
+        ValidationResult failure1 = ValidationResult.failure("Error 1");
+        ValidationResult failure2 = ValidationResult.failure("Error 2");
+        ValidationResult failure3 = ValidationResult.failure("Error 3");
+
+        ValidationResult combined = ValidationResult.combine(failure1, failure2, failure3);
+
+        assertFalse(combined.isValid());
+        assertEquals(3, combined.getErrors().size());
+    }
+
+    @Test
+    public void testGetFormattedErrorsSingleError() {
+        ValidationResult result = ValidationResult.failure("Single error message");
+        String formatted = result.getFormattedErrors();
+
+        assertEquals("Validation failed: Single error message", formatted);
+    }
+
+    @Test
+    public void testGetFormattedErrorsSingleErrorWithField() {
+        ValidationResult result = ValidationResult.failure("testField", "Field error message");
+        String formatted = result.getFormattedErrors();
+
+        assertEquals("Validation failed for field 'testField': Field error message", formatted);
+    }
+
+    @Test
+    public void testGetFormattedErrorsMultipleErrors() {
+        List<String> errors = Arrays.asList("Error 1", "Error 2", "Error 3");
+        ValidationResult result = ValidationResult.failure(errors);
+        String formatted = result.getFormattedErrors();
+
+        assertTrue(formatted.startsWith("Validation failed: \n"));
+        assertTrue(formatted.contains("1. Error 1"));
+        assertTrue(formatted.contains("2. Error 2"));
+        assertTrue(formatted.contains("3. Error 3"));
+    }
+
+    @Test
+    public void testGetFormattedErrorsMultipleErrorsWithField() {
+        List<String> errors = Arrays.asList("Error 1", "Error 2");
+        ValidationResult result = ValidationResult.failure("testField", errors);
+        String formatted = result.getFormattedErrors();
+
+        assertTrue(formatted.startsWith("Validation failed for field 'testField': \n"));
+        assertTrue(formatted.contains("1. Error 1"));
+        assertTrue(formatted.contains("2. Error 2"));
+    }
+
+    @Test
+    public void testGetFormattedErrorsNoErrors() {
+        ValidationResult result = ValidationResult.success();
+        assertEquals("", result.getFormattedErrors());
+    }
+
+    @Test
+    public void testToStringSuccess() {
+        ValidationResult result1 = ValidationResult.success();
+        assertEquals("ValidationResult{valid=true}", result1.toString());
+
+        ValidationResult result2 = ValidationResult.success("testField");
+        assertEquals("ValidationResult{valid=true, field='testField'}", result2.toString());
+    }
+
+    @Test
+    public void testToStringFailure() {
+        ValidationResult result1 = ValidationResult.failure("Error");
+        assertEquals("ValidationResult{valid=false, errors=[Error]}", result1.toString());
+
+        ValidationResult result2 = ValidationResult.failure("testField", "Error");
+        assertEquals(
+                "ValidationResult{valid=false, field='testField', errors=[Error]}",
+                result2.toString());
+    }
+
+    @Test
+    public void testErrorListIsImmutable() {
+        List<String> mutableErrors = Arrays.asList("Error 1", "Error 2");
+        ValidationResult result = ValidationResult.failure(mutableErrors);
+
+        // Should not be able to modify the errors list
+        assertThrows(
+                UnsupportedOperationException.class, () -> result.getErrors().add("New Error"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added validation functionality for ModifiableVariableProperty annotations
- Implemented length constraint validation (minLength/maxLength) for byte arrays and strings
- Added validateProperty() methods to ModifiableVariable and validatePropertyAnnotations() to ModifiableVariableHolder
- Created comprehensive test suite and example demonstrating usage

## Description
This PR addresses issue #555 by reintegrating validation functionality for the ModifiableVariableProperty annotation. The ModifiableVariableProperty annotation defines constraints like minLength and maxLength, but these were not being enforced at runtime. This implementation adds the missing validation infrastructure.

### Key Changes:
1. **ValidationResult class**: Encapsulates validation results with detailed error messages
2. **ModifiableVariableValidator**: Provides static methods for validating variables and objects
3. **Integration with base classes**: Added validation methods to ModifiableVariable and ModifiableVariableHolder
4. **Length validation**: Implemented for ModifiableByteArray and ModifiableString (UTF-8 byte length)
5. **Fluent API**: Support for custom validation rules through ValidatorContext
6. **Recursive validation**: Supports nested objects marked with @HoldsModifiableVariable

### Example Usage:
```java
@ModifiableVariableProperty(minLength = 32, maxLength = 32)
private ModifiableByteArray nonce;

// Validate individual field
ValidationResult result = nonce.validateProperty(property);

// Validate entire object
ValidationResult objectResult = message.validatePropertyAnnotations();
```

## Test plan
- [x] Run all unit tests: `mvn test`
- [x] Run validation-specific tests: `mvn test -Dtest=*Validation*`
- [x] Verify example compiles and runs: `mvn test -Dtest=ValidationExample`
- [x] Check code formatting: `mvn spotless:check`
- [x] Run static analysis: `mvn pmd:pmd pmd:cpd spotbugs:spotbugs`

Fixes tls-attacker/TLS-Attacker-Development#555