### PR TITLE
Remove public modifiers from test classes and methods

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/HoldsModifiableVariableTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/HoldsModifiableVariableTest.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class HoldsModifiableVariableTest {
+class HoldsModifiableVariableTest {
 
     // Test class with HoldsModifiableVariable annotations
     private static class TestClass {

--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableFactoryTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableFactoryTest.java
@@ -21,10 +21,10 @@ import de.rub.nds.modifiablevariable.string.ModifiableString;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableVariableFactoryTest {
+class ModifiableVariableFactoryTest {
 
     @Test
-    public void testSafelySetValueBigInteger() {
+    void testSafelySetValueBigInteger() {
         // Test with null ModifiableBigInteger
         BigInteger originalValue = new BigInteger("12345");
         ModifiableBigInteger result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -42,7 +42,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueString() {
+    void testSafelySetValueString() {
         // Test with null ModifiableString
         String originalValue = "test string";
         ModifiableString result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -60,7 +60,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueInteger() {
+    void testSafelySetValueInteger() {
         // Test with null ModifiableInteger
         Integer originalValue = 42;
         ModifiableInteger result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -78,7 +78,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueByte() {
+    void testSafelySetValueByte() {
         // Test with null ModifiableByte
         Byte originalValue = (byte) 0xAB;
         ModifiableByte result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -95,7 +95,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueByteArray() {
+    void testSafelySetValueByteArray() {
         // Test with null ModifiableByteArray
         byte[] originalValue = new byte[] {0x01, 0x02, 0x03};
         ModifiableByteArray result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -119,7 +119,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueLong() {
+    void testSafelySetValueLong() {
         // Test with null ModifiableLong
         Long originalValue = 9999999999L;
         ModifiableLong result = ModifiableVariableFactory.safelySetValue(null, originalValue);
@@ -136,7 +136,7 @@ public class ModifiableVariableFactoryTest {
     }
 
     @Test
-    public void testSafelySetValueBoolean() {
+    void testSafelySetValueBoolean() {
         // Test with null ModifiableBoolean
         Boolean originalValue = Boolean.TRUE;
         ModifiableBoolean result = ModifiableVariableFactory.safelySetValue(null, originalValue);

--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableHolderTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableHolderTest.java
@@ -21,7 +21,7 @@ import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableVariableHolderTest {
+class ModifiableVariableHolderTest {
 
     private TestModifiableVariableHolder holder;
 
@@ -34,7 +34,7 @@ public class ModifiableVariableHolderTest {
         private String regularString;
         private NestedHolder nestedHolder;
 
-        public TestModifiableVariableHolder() {
+        TestModifiableVariableHolder() {
             intValue = new ModifiableInteger();
             stringValue = new ModifiableString();
             byteArrayValue = new ModifiableByteArray();
@@ -47,14 +47,14 @@ public class ModifiableVariableHolderTest {
     private static class NestedHolder extends ModifiableVariableHolder {
         private ModifiableInteger nestedInt;
 
-        public NestedHolder() {
+        NestedHolder() {
             nestedInt = new ModifiableInteger();
             nestedInt.setOriginalValue(42);
         }
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         holder = new TestModifiableVariableHolder();
         holder.intValue.setOriginalValue(123);
         holder.stringValue.setOriginalValue("Test String");
@@ -62,7 +62,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testGetAllModifiableVariableFields() {
+    void testGetAllModifiableVariableFields() {
         List<Field> fields = holder.getAllModifiableVariableFields();
 
         // Should find 3 fields: intValue, stringValue, byteArrayValue
@@ -93,7 +93,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testGetRandomModifiableVariableField() {
+    void testGetRandomModifiableVariableField() {
         // Use a fixed seed for reproducible test
         Random random = new Random(123);
 
@@ -103,7 +103,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testGetAllModifiableVariableHolders() {
+    void testGetAllModifiableVariableHolders() {
         List<ModifiableVariableHolder> holders = holder.getAllModifiableVariableHolders();
 
         // Should only contain the holder itself by default
@@ -112,7 +112,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testGetRandomModifiableVariableHolder() {
+    void testGetRandomModifiableVariableHolder() {
         // Use a fixed seed for reproducible test
         Random random = new Random(123);
 
@@ -122,7 +122,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testReset() {
+    void testReset() {
         // Apply a modification to test reset
         VariableModification<Integer> modification =
                 new VariableModification<Integer>() {
@@ -150,7 +150,7 @@ public class ModifiableVariableHolderTest {
     }
 
     @Test
-    public void testGetExtendedString() {
+    void testGetExtendedString() {
         String result = holder.getExtendedString();
         System.out.println("Extended string content: " + result);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariablePropertyTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariablePropertyTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableVariablePropertyTest {
+class ModifiableVariablePropertyTest {
 
     // Test class with annotated fields
     private static class TestClass {
@@ -54,7 +54,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testLengthProperty() throws NoSuchFieldException {
+    void testLengthProperty() throws NoSuchFieldException {
         Field lengthField = TestClass.class.getDeclaredField("length");
         ModifiableVariableProperty annotation =
                 lengthField.getAnnotation(ModifiableVariableProperty.class);
@@ -67,7 +67,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testCountProperty() throws NoSuchFieldException {
+    void testCountProperty() throws NoSuchFieldException {
         Field countField = TestClass.class.getDeclaredField("count");
         ModifiableVariableProperty annotation =
                 countField.getAnnotation(ModifiableVariableProperty.class);
@@ -80,7 +80,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testSignatureWithEncodingProperty() throws NoSuchFieldException {
+    void testSignatureWithEncodingProperty() throws NoSuchFieldException {
         Field signatureField = TestClass.class.getDeclaredField("signatureWithEncoding");
         ModifiableVariableProperty annotation =
                 signatureField.getAnnotation(ModifiableVariableProperty.class);
@@ -91,7 +91,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testDefaultProperty() throws NoSuchFieldException {
+    void testDefaultProperty() throws NoSuchFieldException {
         Field defaultField = TestClass.class.getDeclaredField("defaultProperty");
         ModifiableVariableProperty annotation =
                 defaultField.getAnnotation(ModifiableVariableProperty.class);
@@ -104,7 +104,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testEnhancedProperty() throws NoSuchFieldException {
+    void testEnhancedProperty() throws NoSuchFieldException {
         Field enhancedField = TestClass.class.getDeclaredField("enhancedProperty");
         ModifiableVariableProperty annotation =
                 enhancedField.getAnnotation(ModifiableVariableProperty.class);
@@ -117,7 +117,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testNewPurposeEnums() throws NoSuchFieldException {
+    void testNewPurposeEnums() throws NoSuchFieldException {
         Field versionField = TestClass.class.getDeclaredField("protocolVersion");
         ModifiableVariableProperty versionAnnotation =
                 versionField.getAnnotation(ModifiableVariableProperty.class);
@@ -143,7 +143,7 @@ public class ModifiableVariablePropertyTest {
     }
 
     @Test
-    public void testModifiableVariableAnalyzer() {
+    void testModifiableVariableAnalyzer() {
         List<Field> annotatedFields =
                 ModifiableVariableAnalyzer.getAnnotatedFields(TestClass.class);
         assertEquals(8, annotatedFields.size()); // 8 annotated fields in TestClass

--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableTest.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableVariableTest {
+class ModifiableVariableTest {
 
     /** Test setModifications with a list of modifications. */
     @Test
-    public void testSetModifications() {
+    void testSetModifications() {
         ModifiableInteger integer = new ModifiableInteger();
         integer.setOriginalValue(100);
 
@@ -39,7 +39,7 @@ public class ModifiableVariableTest {
 
     /** Test clear modifications. */
     @Test
-    public void testClearModifications() {
+    void testClearModifications() {
         ModifiableInteger integer = new ModifiableInteger();
         integer.setOriginalValue(100);
 
@@ -56,7 +56,7 @@ public class ModifiableVariableTest {
 
     /** Test addModification with null. */
     @Test
-    public void testAddModificationWithNull() {
+    void testAddModificationWithNull() {
         ModifiableInteger integer = new ModifiableInteger();
         integer.setOriginalValue(100);
 
@@ -69,7 +69,7 @@ public class ModifiableVariableTest {
 
     /** Test copy constructor with modifications. */
     @Test
-    public void testCopyConstructorWithModifications() {
+    void testCopyConstructorWithModifications() {
         // Create and set up original instance
         ModifiableInteger original = new ModifiableInteger();
         original.setOriginalValue(100);
@@ -87,7 +87,7 @@ public class ModifiableVariableTest {
 
     /** Test getModifications method. */
     @Test
-    public void testGetModifications() {
+    void testGetModifications() {
         ModifiableInteger integer = new ModifiableInteger();
         integer.setOriginalValue(100);
 
@@ -114,7 +114,7 @@ public class ModifiableVariableTest {
 
     /** Test containsAssertion method. */
     @Test
-    public void testContainsAssertion() {
+    void testContainsAssertion() {
         ModifiableInteger integer = new ModifiableInteger();
 
         // Initially no assertion
@@ -131,7 +131,7 @@ public class ModifiableVariableTest {
 
     /** Test innerToString method through subclass toString. */
     @Test
-    public void testInnerToString() {
+    void testInnerToString() {
         // Test with no modifications or assertions
         ModifiableInteger integer1 = new ModifiableInteger();
         integer1.setOriginalValue(100);

--- a/src/test/java/de/rub/nds/modifiablevariable/VariableModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/VariableModificationTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Tests for the {@link VariableModification} abstract class. */
-public class VariableModificationTest {
+class VariableModificationTest {
 
     private TestAppender testAppender;
     private Logger logger;
@@ -51,13 +51,13 @@ public class VariableModificationTest {
             logEvents.add(event.toImmutable());
         }
 
-        public List<LogEvent> getLogEvents() {
+        List<LogEvent> getLogEvents() {
             return new ArrayList<>(logEvents);
         }
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         // Set up logger with a test appender to capture log events
         logger =
                 (org.apache.logging.log4j.core.Logger)
@@ -69,7 +69,7 @@ public class VariableModificationTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         logger.removeAppender(testAppender);
         testAppender.stop();
     }
@@ -125,7 +125,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testModifyWithNonNullInput() {
+    void testModifyWithNonNullInput() {
         VariableModification<String> modification = new TestModification();
         String input = "test";
         String result = modification.modify(input);
@@ -134,7 +134,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testModifyWithNullInput() {
+    void testModifyWithNullInput() {
         VariableModification<String> modification = new TestModification();
         String result = modification.modify(null);
 
@@ -142,7 +142,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testModifyReturningNull() {
+    void testModifyReturningNull() {
         VariableModification<String> modification = new NullReturningModification();
         String result = modification.modify("any input");
 
@@ -150,7 +150,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testDebugLoggingWithNonNullValue() {
+    void testDebugLoggingWithNonNullValue() {
         VariableModification<String> modification = new TestModification();
         modification.modify("test");
 
@@ -167,7 +167,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testDebugLoggingWithNullValue() {
+    void testDebugLoggingWithNullValue() {
         VariableModification<String> modification = new NullReturningModification();
         modification.modify("will return null");
 
@@ -184,7 +184,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testModifyByteArray() {
+    void testModifyByteArray() {
         VariableModification<byte[]> modification = new ByteArrayModification();
         byte[] input = new byte[] {1, 2, 3};
         byte[] result = modification.modify(input);
@@ -196,7 +196,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         VariableModification<String> original = new TestModification();
         VariableModification<String> copy = original.createCopy();
 
@@ -208,7 +208,7 @@ public class VariableModificationTest {
     }
 
     @Test
-    public void testDebugLoggingWithStringValue() {
+    void testDebugLoggingWithStringValue() {
         VariableModification<String> modification = new TestModification();
         modification.modify("test\nwith\tspecial\"chars");
 

--- a/src/test/java/de/rub/nds/modifiablevariable/assertion/AssertionTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/assertion/AssertionTest.java
@@ -17,14 +17,14 @@ import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class AssertionTest {
+class AssertionTest {
 
     private ModifiableInteger mi;
 
     private ModifiableByteArray mba;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         mi = new ModifiableInteger();
         mi.setOriginalValue(10);
         mba = new ModifiableByteArray();
@@ -32,7 +32,7 @@ public class AssertionTest {
     }
 
     @Test
-    public void testAssertionInteger() {
+    void testAssertionInteger() {
         mi.setAssertEquals(10);
         assertTrue(mi.validateAssertions());
         mi.setAssertEquals(0);
@@ -40,7 +40,7 @@ public class AssertionTest {
     }
 
     @Test
-    public void testAddInteger() {
+    void testAddInteger() {
         VariableModification<Integer> modifier = new IntegerAddModification(1);
         mi.setModifications(modifier);
         mi.setAssertEquals(11);
@@ -48,7 +48,7 @@ public class AssertionTest {
     }
 
     @Test
-    public void testAssertionByteArray() {
+    void testAssertionByteArray() {
         mba.setAssertEquals(new byte[] {0, 1});
         assertTrue(mba.validateAssertions());
         mba.setAssertEquals(new byte[] {0, 0});

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerAddModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerAddModificationTest.java
@@ -17,14 +17,14 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerAddModificationTest {
+class BigIntegerAddModificationTest {
 
     private BigIntegerAddModification b1;
     private BigIntegerAddModification b2;
     private BigIntegerAddModification b3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new BigIntegerAddModification(BigInteger.ONE);
         b2 = new BigIntegerAddModification(BigInteger.TEN);
         b3 = new BigIntegerAddModification(BigInteger.ONE);
@@ -32,7 +32,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of modifyImplementationHook method, of class BigIntegerAddModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         assertEquals(BigInteger.valueOf(11), b1.modifyImplementationHook(BigInteger.TEN));
         assertEquals(BigInteger.valueOf(2), b3.modifyImplementationHook(BigInteger.ONE));
         assertEquals(null, b1.modifyImplementationHook(null));
@@ -40,14 +40,14 @@ public class BigIntegerAddModificationTest {
 
     /** Test of getSummand method, of class BigIntegerAddModification. */
     @Test
-    public void testGetSummand() {
+    void testGetSummand() {
         assertEquals(BigInteger.ONE, b1.getSummand());
         assertEquals(BigInteger.TEN, b2.getSummand());
     }
 
     /** Test of setSummand method, of class BigIntegerAddModification. */
     @Test
-    public void testSetSummand() {
+    void testSetSummand() {
         assertNotEquals(BigInteger.ONE, b2.getSummand());
         b2.setSummand(BigInteger.ONE);
         assertEquals(BigInteger.ONE, b2.getSummand());
@@ -55,20 +55,20 @@ public class BigIntegerAddModificationTest {
 
     /** Test that setSummand throws NullPointerException if given null */
     @Test
-    public void testSetSummandWithNull() {
+    void testSetSummandWithNull() {
         assertThrows(NullPointerException.class, () -> b1.setSummand(null));
     }
 
     /** Test that constructor throws NullPointerException if given null */
     @Test
-    public void testConstructorWithNull() {
+    void testConstructorWithNull() {
         assertThrows(
                 NullPointerException.class, () -> new BigIntegerAddModification((BigInteger) null));
     }
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BigIntegerAddModification copy = b1.createCopy();
 
         // Verify the copy has the same properties
@@ -87,7 +87,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of hashCode method, of class BigIntegerAddModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Equal objects should have same hash code
         assertEquals(b1.hashCode(), b3.hashCode());
 
@@ -102,7 +102,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method with reflexivity property */
     @Test
-    public void testEqualsReflexivity() {
+    void testEqualsReflexivity() {
         // An object must equal itself
         assertTrue(b1.equals(b1));
         assertTrue(b2.equals(b2));
@@ -111,7 +111,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method with symmetry property */
     @Test
-    public void testEqualsSymmetry() {
+    void testEqualsSymmetry() {
         // If a equals b, then b equals a
         assertTrue(b1.equals(b3));
         assertTrue(b3.equals(b1));
@@ -122,7 +122,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method with transitivity property */
     @Test
-    public void testEqualsTransitivity() {
+    void testEqualsTransitivity() {
         // If a equals b and b equals c, then a equals c
         BigIntegerAddModification b4 = new BigIntegerAddModification(BigInteger.ONE);
 
@@ -133,7 +133,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method with null comparison */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         // Comparison with null should return false
         assertFalse(b1.equals(null));
         assertFalse(b2.equals(null));
@@ -142,7 +142,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method with different object types */
     @Test
-    public void testEqualsDifferentTypes() {
+    void testEqualsDifferentTypes() {
         // Comparison with different types should return false
         assertFalse(b1.equals("Not a BigIntegerAddModification"));
         assertFalse(b1.equals(BigInteger.ONE));
@@ -151,7 +151,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of equals method after state change */
     @Test
-    public void testEqualsAfterStateChange() {
+    void testEqualsAfterStateChange() {
         // Initially equal
         assertTrue(b1.equals(b3));
 
@@ -170,7 +170,7 @@ public class BigIntegerAddModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String toString = b1.toString();
 
         // Verify the string contains the class name and summand value

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModificationTest.java
@@ -18,7 +18,7 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerExplicitValueModificationTest {
+class BigIntegerExplicitValueModificationTest {
 
     private BigIntegerExplicitValueModification b1;
     private BigIntegerExplicitValueModification b2;
@@ -26,7 +26,7 @@ public class BigIntegerExplicitValueModificationTest {
     private Integer integer1;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new BigIntegerExplicitValueModification(BigInteger.ONE);
         b2 = new BigIntegerExplicitValueModification(BigInteger.TEN);
         b3 = new BigIntegerExplicitValueModification(BigInteger.ONE);
@@ -35,7 +35,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Should always return explicit value, regardless of input
         assertEquals(BigInteger.ONE, b1.modifyImplementationHook(BigInteger.ZERO));
         assertEquals(BigInteger.ONE, b1.modifyImplementationHook(BigInteger.valueOf(-42)));
@@ -48,13 +48,13 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of getExplicitValue method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testGetExplicitValue() {
+    void testGetExplicitValue() {
         assertEquals(BigInteger.ONE, b1.getExplicitValue());
     }
 
     /** Test of setExplicitValue method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testSetExplicitValue() {
+    void testSetExplicitValue() {
         // Change explicit value and verify
         assertNotEquals(BigInteger.valueOf(42), b1.getExplicitValue());
         b1.setExplicitValue(BigInteger.valueOf(42));
@@ -63,7 +63,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of hashCode method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Same explicit value should have same hash code
         assertEquals(b1.hashCode(), b3.hashCode());
 
@@ -91,7 +91,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of equals method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same instance
         assertTrue(b1.equals(b1));
 
@@ -125,7 +125,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BigIntegerExplicitValueModification copy = b1.createCopy();
 
         // Verify it's a different instance but equal
@@ -142,7 +142,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String toString = b1.toString();
         assertTrue(toString.contains("BigIntegerExplicitValueModification"));
         assertTrue(toString.contains("explicitValue=1"));
@@ -155,7 +155,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorWithNullValue() {
+    void testConstructorWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
@@ -170,7 +170,7 @@ public class BigIntegerExplicitValueModificationTest {
 
     /** Test setExplicitValue with null value */
     @Test
-    public void testSetExplicitValueWithNullValue() {
+    void testSetExplicitValueWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             b1.setExplicitValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerModificationTest.java
@@ -14,14 +14,14 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerModificationTest {
+class BigIntegerModificationTest {
 
     private ModifiableBigInteger start;
 
     private BigInteger expectedResult, result;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         start = new ModifiableBigInteger();
         start.setOriginalValue(BigInteger.TEN);
         expectedResult = null;
@@ -30,7 +30,7 @@ public class BigIntegerModificationTest {
 
     /** Test of add method, of class BigIntegerAddModification. */
     @Test
-    public void testAdd() {
+    void testAdd() {
         VariableModification<BigInteger> modifier = new BigIntegerAddModification(BigInteger.ONE);
         start.setModifications(modifier);
         expectedResult = new BigInteger("11");
@@ -42,7 +42,7 @@ public class BigIntegerModificationTest {
 
     /** Test of sub method, of class BigIntegerSubtractModification. */
     @Test
-    public void testSub() {
+    void testSub() {
         VariableModification<BigInteger> modifier =
                 new BigIntegerSubtractModification(BigInteger.ONE);
         start.setModifications(modifier);
@@ -55,7 +55,7 @@ public class BigIntegerModificationTest {
 
     /** Test of xor method, of class BigIntegerXorModification. */
     @Test
-    public void testXor() {
+    void testXor() {
         VariableModification<BigInteger> modifier =
                 new BigIntegerXorModification(new BigInteger("2"));
         start.setModifications(modifier);
@@ -68,7 +68,7 @@ public class BigIntegerModificationTest {
 
     /** Test of explicitValue method, of class BigIntegerExplicitValueModification. */
     @Test
-    public void testExplicitValue() {
+    void testExplicitValue() {
         VariableModification<BigInteger> modifier =
                 new BigIntegerExplicitValueModification(new BigInteger("7"));
         start.setModifications(modifier);
@@ -81,7 +81,7 @@ public class BigIntegerModificationTest {
 
     /** Test of add method, of class BigIntegerAddModification. */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         assertFalse(start.isOriginalValueModified());
         VariableModification<BigInteger> modifier = new BigIntegerAddModification(BigInteger.ZERO);
         start.setModifications(modifier);
@@ -92,7 +92,7 @@ public class BigIntegerModificationTest {
     }
 
     @Test
-    public void testShiftLeft() {
+    void testShiftLeft() {
         VariableModification<BigInteger> modifier = new BigIntegerShiftLeftModification(2);
         start.setModifications(modifier);
         expectedResult = new BigInteger("40");
@@ -103,7 +103,7 @@ public class BigIntegerModificationTest {
     }
 
     @Test
-    public void testShiftRight() {
+    void testShiftRight() {
         VariableModification<BigInteger> modifier = new BigIntegerShiftRightModification(1);
         start.setModifications(modifier);
         expectedResult = new BigInteger("5");

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerMultiplyModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerMultiplyModificationTest.java
@@ -17,14 +17,14 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerMultiplyModificationTest {
+class BigIntegerMultiplyModificationTest {
 
     private BigIntegerMultiplyModification m1;
     private BigIntegerMultiplyModification m2;
     private BigIntegerMultiplyModification m3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         m1 = new BigIntegerMultiplyModification(BigInteger.valueOf(2));
         m2 = new BigIntegerMultiplyModification(BigInteger.valueOf(5));
         m3 = new BigIntegerMultiplyModification(BigInteger.valueOf(2));
@@ -32,7 +32,7 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of modifyImplementationHook method */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Regular multiplication
         assertEquals(BigInteger.valueOf(20), m1.modifyImplementationHook(BigInteger.TEN));
         assertEquals(BigInteger.valueOf(50), m2.modifyImplementationHook(BigInteger.TEN));
@@ -47,14 +47,14 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of getFactor method */
     @Test
-    public void testGetFactor() {
+    void testGetFactor() {
         assertEquals(BigInteger.valueOf(2), m1.getFactor());
         assertEquals(BigInteger.valueOf(5), m2.getFactor());
     }
 
     /** Test of setFactor method */
     @Test
-    public void testSetFactor() {
+    void testSetFactor() {
         // Change factor and verify
         assertNotEquals(BigInteger.valueOf(3), m1.getFactor());
         m1.setFactor(BigInteger.valueOf(3));
@@ -66,7 +66,7 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of hashCode method */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Same factor should have same hash code
         assertEquals(m1.hashCode(), m3.hashCode());
 
@@ -87,7 +87,7 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of equals method */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same instance
         assertTrue(m1.equals(m1));
 
@@ -120,7 +120,7 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BigIntegerMultiplyModification copy = m1.createCopy();
 
         // Verify it's a different instance but equal
@@ -135,7 +135,7 @@ public class BigIntegerMultiplyModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String toString = m1.toString();
         assertTrue(toString.contains("BigIntegerMultiplyModification"));
         assertTrue(toString.contains("factor=2"));

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerOperationConcatenationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerOperationConcatenationTest.java
@@ -14,20 +14,20 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerOperationConcatenationTest {
+class BigIntegerOperationConcatenationTest {
 
     private ModifiableBigInteger start;
 
     private BigInteger expectedResult, result;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         start = new ModifiableBigInteger();
         start.setOriginalValue(BigInteger.TEN);
     }
 
     @Test
-    public void testAddThenMultiplyWithInnerClass() {
+    void testAddThenMultiplyWithInnerClass() {
         // (input + 4) ^ 3 = (10 + 4) ^ 3 = 13
         start.setModifications(
                 new VariableModification<>() {

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftLeftModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftLeftModificationTest.java
@@ -16,20 +16,20 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerShiftLeftModificationTest {
+class BigIntegerShiftLeftModificationTest {
 
     private ModifiableBigInteger modifiableBigInteger;
     private BigInteger originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableBigInteger = new ModifiableBigInteger();
         originalValue = new BigInteger("12345678901234567890");
         modifiableBigInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testShiftLeftModification() {
+    void testShiftLeftModification() {
         int shift = 8;
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(shift);
         modifiableBigInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftNegativeNumber() {
+    void testShiftLeftNegativeNumber() {
         BigInteger negativeValue = new BigInteger("-987654321");
         modifiableBigInteger.setOriginalValue(negativeValue);
 
@@ -56,7 +56,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithZeroShift() {
+    void testShiftLeftWithZeroShift() {
         int shift = 0;
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(shift);
         modifiableBigInteger.setModifications(modification);
@@ -68,7 +68,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithLargeShift() {
+    void testShiftLeftWithLargeShift() {
         int shift = 128;
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(shift);
         modifiableBigInteger.setModifications(modification);
@@ -80,7 +80,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithNullInput() {
+    void testShiftLeftWithNullInput() {
         modifiableBigInteger.setOriginalValue(null);
 
         int shift = 10;
@@ -94,7 +94,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int shift = 15;
         BigIntegerShiftLeftModification modification1 = new BigIntegerShiftLeftModification(shift);
         BigIntegerShiftLeftModification modification2 = new BigIntegerShiftLeftModification(shift);
@@ -111,7 +111,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testEqualsComprehensive() {
+    void testEqualsComprehensive() {
         // Same instance equality (reflexivity)
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(8);
         assertTrue(modification.equals(modification));
@@ -167,7 +167,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testGetterAndSetter() {
+    void testGetterAndSetter() {
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(5);
 
         int shift = 25;
@@ -177,7 +177,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int shift = 12;
         BigIntegerShiftLeftModification original = new BigIntegerShiftLeftModification(shift);
         BigIntegerShiftLeftModification copy = original.createCopy();
@@ -197,7 +197,7 @@ public class BigIntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int shift = 7;
         BigIntegerShiftLeftModification modification = new BigIntegerShiftLeftModification(shift);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftRightModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerShiftRightModificationTest.java
@@ -16,20 +16,20 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerShiftRightModificationTest {
+class BigIntegerShiftRightModificationTest {
 
     private ModifiableBigInteger modifiableBigInteger;
     private BigInteger originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableBigInteger = new ModifiableBigInteger();
         originalValue = new BigInteger("12345678901234567890");
         modifiableBigInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testShiftRightModification() {
+    void testShiftRightModification() {
         int shift = 8;
         BigIntegerShiftRightModification modification = new BigIntegerShiftRightModification(shift);
         modifiableBigInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightNegativeNumber() {
+    void testShiftRightNegativeNumber() {
         BigInteger negativeValue = new BigInteger("-987654321");
         modifiableBigInteger.setOriginalValue(negativeValue);
 
@@ -56,7 +56,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithZeroShift() {
+    void testShiftRightWithZeroShift() {
         int shift = 0;
         BigIntegerShiftRightModification modification = new BigIntegerShiftRightModification(shift);
         modifiableBigInteger.setModifications(modification);
@@ -68,7 +68,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithLargeShift() {
+    void testShiftRightWithLargeShift() {
         // First set a large value to have meaningful results after a large right shift
         BigInteger largeValue = originalValue.shiftLeft(200);
         modifiableBigInteger.setOriginalValue(largeValue);
@@ -84,7 +84,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNullInput() {
+    void testShiftRightWithNullInput() {
         modifiableBigInteger.setOriginalValue(null);
 
         int shift = 10;
@@ -98,7 +98,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int shift = 15;
         BigIntegerShiftRightModification modification1 =
                 new BigIntegerShiftRightModification(shift);
@@ -117,7 +117,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testEqualsComprehensive() {
+    void testEqualsComprehensive() {
         // Same instance equality (reflexivity)
         BigIntegerShiftRightModification modification = new BigIntegerShiftRightModification(8);
         assertTrue(modification.equals(modification));
@@ -173,7 +173,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testGetterAndSetter() {
+    void testGetterAndSetter() {
         BigIntegerShiftRightModification modification = new BigIntegerShiftRightModification(5);
 
         int shift = 25;
@@ -183,7 +183,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int shift = 12;
         BigIntegerShiftRightModification original = new BigIntegerShiftRightModification(shift);
         BigIntegerShiftRightModification copy = original.createCopy();
@@ -203,7 +203,7 @@ public class BigIntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int shift = 7;
         BigIntegerShiftRightModification modification = new BigIntegerShiftRightModification(shift);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModificationTest.java
@@ -18,7 +18,7 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerSubtractModificationTest {
+class BigIntegerSubtractModificationTest {
 
     private BigIntegerSubtractModification b1;
     private BigIntegerSubtractModification b2;
@@ -26,7 +26,7 @@ public class BigIntegerSubtractModificationTest {
     private Integer integer1;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new BigIntegerSubtractModification(BigInteger.ONE);
         b2 = new BigIntegerSubtractModification(BigInteger.TEN);
         b3 = new BigIntegerSubtractModification(BigInteger.ONE);
@@ -35,7 +35,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of modifyImplementationHook method, of class BigIntegerSubtractModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Regular subtraction
         assertEquals(BigInteger.valueOf(9), b1.modifyImplementationHook(BigInteger.TEN));
         assertEquals(BigInteger.valueOf(0), b2.modifyImplementationHook(BigInteger.TEN));
@@ -53,7 +53,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of getSubtrahend method, of class BigIntegerSubtractModification. */
     @Test
-    public void testGetSubtrahend() {
+    void testGetSubtrahend() {
         assertEquals(BigInteger.ONE, b1.getSubtrahend());
         assertEquals(BigInteger.TEN, b2.getSubtrahend());
 
@@ -63,7 +63,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of setSubtrahend method, of class BigIntegerSubtractModification. */
     @Test
-    public void testSetSubtrahend() {
+    void testSetSubtrahend() {
         // Change subtrahend and verify
         assertNotEquals(BigInteger.valueOf(5), b1.getSubtrahend());
         b1.setSubtrahend(BigInteger.valueOf(5));
@@ -75,7 +75,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of hashCode method, of class BigIntegerSubtractModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Same subtrahend should have same hash code
         assertEquals(b1.hashCode(), b3.hashCode());
 
@@ -102,7 +102,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of equals method, of class BigIntegerSubtractModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same instance
         assertTrue(b1.equals(b1));
 
@@ -135,7 +135,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BigIntegerSubtractModification copy = b1.createCopy();
 
         // Verify it's a different instance but equal
@@ -152,7 +152,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String toString = b1.toString();
         assertTrue(toString.contains("BigIntegerSubtractModification"));
         assertTrue(toString.contains("subtrahend=1"));
@@ -165,7 +165,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorWithNullValue() {
+    void testConstructorWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
@@ -181,7 +181,7 @@ public class BigIntegerSubtractModificationTest {
 
     /** Test setSubtrahend with null value */
     @Test
-    public void testSetSubtrahendWithNullValue() {
+    void testSetSubtrahendWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             b1.setSubtrahend(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModificationTest.java
@@ -18,7 +18,7 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerXorModificationTest {
+class BigIntegerXorModificationTest {
 
     private BigIntegerXorModification b1;
     private BigIntegerXorModification b2;
@@ -26,7 +26,7 @@ public class BigIntegerXorModificationTest {
     private Integer integer1;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new BigIntegerXorModification(BigInteger.ONE);
         b2 = new BigIntegerXorModification(BigInteger.TEN);
         b3 = new BigIntegerXorModification(BigInteger.ONE);
@@ -35,7 +35,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of modifyImplementationHook method, of class BigIntegerXorModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Basic XOR operations
         // 10 XOR 1 = 11 (binary: 1010 XOR 0001 = 1011)
         assertEquals(BigInteger.valueOf(11), b1.modifyImplementationHook(BigInteger.TEN));
@@ -50,7 +50,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of getXor method, of class BigIntegerXorModification. */
     @Test
-    public void testGetXor() {
+    void testGetXor() {
         assertEquals(BigInteger.ONE, b1.getXor());
         assertEquals(BigInteger.TEN, b2.getXor());
 
@@ -60,7 +60,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of setXor method, of class BigIntegerXorModification. */
     @Test
-    public void testSetXor() {
+    void testSetXor() {
         // Change XOR value and verify
         assertNotEquals(BigInteger.valueOf(5), b1.getXor());
         b1.setXor(BigInteger.valueOf(5));
@@ -73,7 +73,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of hashCode method, of class BigIntegerXorModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Same XOR value should have same hash code
         assertEquals(b1.hashCode(), b3.hashCode());
 
@@ -98,7 +98,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of equals method, of class BigIntegerXorModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same instance
         assertTrue(b1.equals(b1));
 
@@ -131,7 +131,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BigIntegerXorModification copy = b1.createCopy();
 
         // Verify it's a different instance but equal
@@ -148,7 +148,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String toString = b1.toString();
         assertTrue(toString.contains("BigIntegerXorModification"));
         assertTrue(toString.contains("xor=1"));
@@ -161,7 +161,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorWithNullValue() {
+    void testConstructorWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
@@ -177,7 +177,7 @@ public class BigIntegerXorModificationTest {
 
     /** Test setXor with null value */
     @Test
-    public void testSetXorWithNullValue() {
+    void testSetXorWithNullValue() {
         // Using try-catch because we expect an exception
         try {
             b1.setXor(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigIntegerTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigIntegerTest.java
@@ -19,13 +19,13 @@ import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableBigIntegerTest {
+class ModifiableBigIntegerTest {
 
     private ModifiableBigInteger integer1;
     private ModifiableBigInteger integer2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         integer1 = new ModifiableBigInteger();
         integer1.setOriginalValue(BigInteger.ONE);
         integer2 = new ModifiableBigInteger();
@@ -34,7 +34,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test default constructor */
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         ModifiableBigInteger defaultInteger = new ModifiableBigInteger();
         assertNull(defaultInteger.getOriginalValue());
         assertNull(defaultInteger.getValue());
@@ -42,7 +42,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test constructor with original value */
     @Test
-    public void testConstructorWithValue() {
+    void testConstructorWithValue() {
         ModifiableBigInteger valueInteger = new ModifiableBigInteger(BigInteger.valueOf(42));
         assertEquals(BigInteger.valueOf(42), valueInteger.getOriginalValue());
         assertEquals(BigInteger.valueOf(42), valueInteger.getValue());
@@ -50,7 +50,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         // Set up an integer with modifications
         integer1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
         integer1.setAssertEquals(BigInteger.valueOf(6));
@@ -67,7 +67,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         // Set up an integer with modifications
         integer1.setModifications(new BigIntegerMultiplyModification(BigInteger.valueOf(3)));
         integer1.setAssertEquals(BigInteger.valueOf(3));
@@ -84,7 +84,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of getAssertEquals and setAssertEquals methods */
     @Test
-    public void testGetAndSetAssertEquals() {
+    void testGetAndSetAssertEquals() {
         // Initially null
         assertNull(integer1.getAssertEquals());
 
@@ -100,7 +100,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of isOriginalValueModified method */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         // Not modified initially
         assertFalse(integer1.isOriginalValueModified());
 
@@ -119,7 +119,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of getByteArray method without arguments */
     @Test
-    public void testGetByteArray_0args() {
+    void testGetByteArray_0args() {
         // Test with positive value
         byte[] expected = new byte[] {0x0A}; // BigInteger.TEN as byte array
         byte[] actual = integer2.getByteArray();
@@ -134,7 +134,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of getByteArray method with size parameter */
     @Test
-    public void testGetByteArray_int() {
+    void testGetByteArray_int() {
         // Test with specific size
         byte[] expected = new byte[] {0x00, 0x00, 0x0A}; // BigInteger.TEN as 3-byte array
         byte[] actual = integer2.getByteArray(3);
@@ -154,7 +154,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of validateAssertions method */
     @Test
-    public void testValidateAssertions() {
+    void testValidateAssertions() {
         // No assertions set initially
         assertTrue(integer1.validateAssertions());
 
@@ -173,7 +173,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of getOriginalValue and setOriginalValue methods */
     @Test
-    public void testGetAndSetOriginalValue() {
+    void testGetAndSetOriginalValue() {
         assertEquals(BigInteger.ONE, integer1.getOriginalValue());
 
         // Set a different value
@@ -190,7 +190,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String expectedToString = "ModifiableBigInteger{originalValue=1}";
         assertEquals(expectedToString, integer1.toString());
 
@@ -206,14 +206,14 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with same object */
     @Test
-    public void testEqualsSameObject() {
+    void testEqualsSameObject() {
         // Same object reference should be equal
         assertTrue(integer1.equals(integer1));
     }
 
     /** Test equals method with same values */
     @Test
-    public void testEqualsSameValues() {
+    void testEqualsSameValues() {
         // Equal objects with same original value
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -223,7 +223,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with modifications */
     @Test
-    public void testEqualsWithModifications() {
+    void testEqualsWithModifications() {
         // Equal objects with same modifications
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -245,7 +245,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with different values */
     @Test
-    public void testEqualsWithDifferentValues() {
+    void testEqualsWithDifferentValues() {
         // Different objects with different modifications
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -256,7 +256,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with different types of modification */
     @Test
-    public void testEqualsWithDifferentModificationTypes() {
+    void testEqualsWithDifferentModificationTypes() {
         // Objects with different types of modifications but same final value
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -272,7 +272,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with null values */
     @Test
-    public void testEqualsWithNullValues() {
+    void testEqualsWithNullValues() {
         // Equal objects with null values
         ModifiableBigInteger nullInteger1 = new ModifiableBigInteger();
         ModifiableBigInteger nullInteger2 = new ModifiableBigInteger();
@@ -287,7 +287,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with null and different types */
     @Test
-    public void testEqualsWithNullAndDifferentTypes() {
+    void testEqualsWithNullAndDifferentTypes() {
         // Inequality with null and different types
         assertFalse(integer1.equals(null));
         assertFalse(integer1.equals("NotABigInteger"));
@@ -297,7 +297,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with explicit values */
     @Test
-    public void testEqualsWithExplicitValues() {
+    void testEqualsWithExplicitValues() {
         // Two objects with different original values but same explicit value
         ModifiableBigInteger integer3 = new ModifiableBigInteger(BigInteger.valueOf(42));
         ModifiableBigInteger integer4 = new ModifiableBigInteger(BigInteger.valueOf(100));
@@ -312,7 +312,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with different modification types but same result */
     @Test
-    public void testEqualsWithDifferentModificationTypesSameResult() {
+    void testEqualsWithDifferentModificationTypesSameResult() {
         // Different modification types resulting in the same final value
         ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(10));
         ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
@@ -336,7 +336,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with chained modifications */
     @Test
-    public void testEqualsWithChainedModifications() {
+    void testEqualsWithChainedModifications() {
         // Two objects with the same chain of modifications
         ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(5));
         ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
@@ -364,7 +364,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test equals method with modified null and non-null original values */
     @Test
-    public void testEqualsWithMixedNullOriginalValues() {
+    void testEqualsWithMixedNullOriginalValues() {
         // Initialize with different original values (one null, one non-null)
         ModifiableBigInteger nullOriginal = new ModifiableBigInteger();
         ModifiableBigInteger nonNullOriginal = new ModifiableBigInteger(BigInteger.valueOf(5));
@@ -392,7 +392,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with basic values */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Equal objects should have same hash code
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -401,7 +401,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with modifications */
     @Test
-    public void testHashCodeWithModifications() {
+    void testHashCodeWithModifications() {
         // Objects with same modified value should have same hash code
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ONE);
@@ -416,7 +416,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with different values */
     @Test
-    public void testHashCodeWithDifferentValues() {
+    void testHashCodeWithDifferentValues() {
         // Objects with different modified values should have different hash codes
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.valueOf(42));
@@ -426,7 +426,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with same result from different original values */
     @Test
-    public void testHashCodeWithSameResult() {
+    void testHashCodeWithSameResult() {
         // Different original values but same final value should have same hash code
         ModifiableBigInteger integer3 = new ModifiableBigInteger();
         integer3.setOriginalValue(BigInteger.ZERO);
@@ -442,7 +442,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with explicit values */
     @Test
-    public void testHashCodeWithExplicitValues() {
+    void testHashCodeWithExplicitValues() {
         // Different original values but same explicit value should have same hash code
         ModifiableBigInteger integer3 = new ModifiableBigInteger(BigInteger.valueOf(42));
         ModifiableBigInteger integer4 = new ModifiableBigInteger(BigInteger.valueOf(100));
@@ -458,7 +458,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode method with null value */
     @Test
-    public void testHashCodeWithNull() {
+    void testHashCodeWithNull() {
         // Null value handling
         ModifiableBigInteger nullInteger = new ModifiableBigInteger();
         int hashCode = nullInteger.hashCode();
@@ -474,7 +474,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode with chained modifications */
     @Test
-    public void testHashCodeWithChainedModifications() {
+    void testHashCodeWithChainedModifications() {
         // Same chain of modifications should produce same hash code
         ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(5));
         ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
@@ -500,7 +500,7 @@ public class ModifiableBigIntegerTest {
 
     /** Test hashCode consistency with equals method */
     @Test
-    public void testHashCodeEqualsConsistency() {
+    void testHashCodeEqualsConsistency() {
         // Objects that are equal must have the same hash code
 
         // Different original values, same final result through different means

--- a/src/test/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModificationTest.java
@@ -16,14 +16,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BooleanExplicitValueModificationTest {
+class BooleanExplicitValueModificationTest {
 
     private BooleanExplicitValueModification b1;
     private BooleanExplicitValueModification b2;
     private BooleanExplicitValueModification b3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new BooleanExplicitValueModification(true);
         b2 = new BooleanExplicitValueModification(false);
         b3 = new BooleanExplicitValueModification(true);
@@ -31,7 +31,7 @@ public class BooleanExplicitValueModificationTest {
 
     /** Test constructor with value */
     @Test
-    public void testConstructorWithValue() {
+    void testConstructorWithValue() {
         BooleanExplicitValueModification modification = new BooleanExplicitValueModification(true);
         assertTrue(modification.getExplicitValue());
 
@@ -42,7 +42,7 @@ public class BooleanExplicitValueModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         BooleanExplicitValueModification original = new BooleanExplicitValueModification(true);
         BooleanExplicitValueModification copy = new BooleanExplicitValueModification(original);
 
@@ -53,34 +53,34 @@ public class BooleanExplicitValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class BooleanExplicitValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         assertTrue(b1.modifyImplementationHook(true));
         assertTrue(b1.modifyImplementationHook(false));
     }
 
     /** Test of modifyImplementationHook method with null input. */
     @Test
-    public void testModifyImplementationHookNullInput() {
+    void testModifyImplementationHookNullInput() {
         assertNull(b1.modifyImplementationHook(null));
     }
 
     /** Test of getExplicitValue method, of class BooleanExplicitValueModification. */
     @Test
-    public void testGetExplicitValue() {
+    void testGetExplicitValue() {
         assertTrue(b1.getExplicitValue());
         assertFalse(b2.getExplicitValue());
     }
 
     /** Test of setExplicitValue method, of class BooleanExplicitValueModification. */
     @Test
-    public void testSetExplicitValue() {
+    void testSetExplicitValue() {
         b2.setExplicitValue(true);
         assertTrue(b2.getExplicitValue());
     }
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BooleanExplicitValueModification copy = b1.createCopy();
 
         assertEquals(b1.getExplicitValue(), copy.getExplicitValue());
@@ -90,21 +90,21 @@ public class BooleanExplicitValueModificationTest {
 
     /** Test of hashCode method, of class BooleanExplicitValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b3.hashCode(), b1.hashCode());
         assertNotEquals(b1.hashCode(), b2.hashCode());
     }
 
     /** Test of equals method with equal objects */
     @Test
-    public void testEqualsTrue() {
+    void testEqualsTrue() {
         assertEquals(b1, b3);
         assertEquals(b1, b1); // Same object
     }
 
     /** Test of equals method with unequal objects */
     @Test
-    public void testEqualsFalse() {
+    void testEqualsFalse() {
         assertNotEquals(b1, b2);
         assertNotEquals(b1, null);
         assertNotEquals(b1, new Object());
@@ -112,7 +112,7 @@ public class BooleanExplicitValueModificationTest {
 
     /** Test of toString method, of class BooleanExplicitValueModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected1 = "BooleanExplicitValueModification{explicitValue=true}";
         String expected2 = "BooleanExplicitValueModification{explicitValue=false}";
 

--- a/src/test/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModificationTest.java
@@ -16,38 +16,38 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BooleanToggleModificationTest {
+class BooleanToggleModificationTest {
 
     private BooleanToggleModification modification1;
     private BooleanToggleModification modification2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification1 = new BooleanToggleModification();
         modification2 = new BooleanToggleModification();
     }
 
     /** Test of modifyImplementationHook method with true input */
     @Test
-    public void testModifyImplementationHookTrue() {
+    void testModifyImplementationHookTrue() {
         assertFalse(modification1.modifyImplementationHook(true));
     }
 
     /** Test of modifyImplementationHook method with false input */
     @Test
-    public void testModifyImplementationHookFalse() {
+    void testModifyImplementationHookFalse() {
         assertTrue(modification1.modifyImplementationHook(false));
     }
 
     /** Test of modifyImplementationHook method with null input */
     @Test
-    public void testModifyImplementationHookNull() {
+    void testModifyImplementationHookNull() {
         assertNull(modification1.modifyImplementationHook(null));
     }
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BooleanToggleModification copy = modification1.createCopy();
         assertEquals(modification1, copy);
         assertNotEquals(System.identityHashCode(modification1), System.identityHashCode(copy));
@@ -55,13 +55,13 @@ public class BooleanToggleModificationTest {
 
     /** Test of hashCode method */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(modification1.hashCode(), modification2.hashCode());
     }
 
     /** Test of equals method with equal objects */
     @Test
-    public void testEqualsTrue() {
+    void testEqualsTrue() {
         assertEquals(modification1, modification2);
         assertEquals(modification1, modification1);
 
@@ -74,14 +74,14 @@ public class BooleanToggleModificationTest {
 
     /** Test of equals method with null */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         assertNotEquals(null, modification1);
         assertFalse(modification1.equals(null));
     }
 
     /** Test of equals method with different class */
     @Test
-    public void testEqualsDifferentClass() {
+    void testEqualsDifferentClass() {
         assertNotEquals(modification1, new Object());
         assertNotEquals(modification1, new BooleanExplicitValueModification(true));
         assertFalse(modification1.equals(new Object()));
@@ -89,7 +89,7 @@ public class BooleanToggleModificationTest {
 
     /** Test equals with a subclass */
     @Test
-    public void testEqualsWithSubclass() {
+    void testEqualsWithSubclass() {
         BooleanToggleModification regularMod = new BooleanToggleModification();
         SubclassToggleModification subclassMod = new SubclassToggleModification();
 
@@ -104,7 +104,7 @@ public class BooleanToggleModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals("BooleanToggleModification{}", modification1.toString());
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/bool/ModifiableBooleanTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bool/ModifiableBooleanTest.java
@@ -18,14 +18,14 @@ import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableBooleanTest {
+class ModifiableBooleanTest {
 
     private ModifiableBoolean boolean1;
     private ModifiableBoolean boolean2;
     private ModifiableBoolean boolean3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         boolean1 = new ModifiableBoolean();
         boolean1.setOriginalValue(Boolean.TRUE);
 
@@ -37,27 +37,27 @@ public class ModifiableBooleanTest {
 
     /** Test of getOriginalValue method, of class ModifiableBoolean. */
     @Test
-    public void testGetOriginalValue() {
+    void testGetOriginalValue() {
         assertEquals(Boolean.TRUE, boolean1.getOriginalValue());
         assertEquals(Boolean.FALSE, boolean3.getOriginalValue());
     }
 
     /** Test of setOriginalValue method, of class ModifiableBoolean. */
     @Test
-    public void testSetOriginalValue() {
+    void testSetOriginalValue() {
         boolean1.setOriginalValue(Boolean.FALSE);
         assertEquals(Boolean.FALSE, boolean1.getOriginalValue());
     }
 
     /** Test of isOriginalValueModified method with unmodified value */
     @Test
-    public void testIsOriginalValueModifiedFalse() {
+    void testIsOriginalValueModifiedFalse() {
         assertFalse(boolean1.isOriginalValueModified());
     }
 
     /** Test of isOriginalValueModified method with modified value */
     @Test
-    public void testIsOriginalValueModifiedTrue() {
+    void testIsOriginalValueModifiedTrue() {
         BooleanToggleModification modification = new BooleanToggleModification();
         boolean1.addModification(modification);
         assertTrue(boolean1.isOriginalValueModified());
@@ -65,27 +65,27 @@ public class ModifiableBooleanTest {
 
     /** Test of isOriginalValueModified method with null original value */
     @Test
-    public void testIsOriginalValueModifiedNull() {
+    void testIsOriginalValueModifiedNull() {
         ModifiableBoolean nullBoolean = new ModifiableBoolean();
         assertThrows(IllegalStateException.class, nullBoolean::isOriginalValueModified);
     }
 
     /** Test of validateAssertions method with no assertions */
     @Test
-    public void testValidateAssertionsNoAssertions() {
+    void testValidateAssertionsNoAssertions() {
         assertTrue(boolean1.validateAssertions());
     }
 
     /** Test of validateAssertions method with assertions equal to value */
     @Test
-    public void testValidateAssertionsEqualValue() throws Exception {
+    void testValidateAssertionsEqualValue() throws Exception {
         setAssertEquals(boolean1, Boolean.TRUE);
         assertTrue(boolean1.validateAssertions());
     }
 
     /** Test of validateAssertions method with assertions not equal to value */
     @Test
-    public void testValidateAssertionsNotEqualValue() throws Exception {
+    void testValidateAssertionsNotEqualValue() throws Exception {
         setAssertEquals(boolean1, Boolean.FALSE);
         assertFalse(boolean1.validateAssertions());
     }
@@ -99,7 +99,7 @@ public class ModifiableBooleanTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ModifiableBoolean{originalValue=true}";
         assertEquals(expected, boolean1.toString());
 
@@ -112,7 +112,7 @@ public class ModifiableBooleanTest {
 
     /** Test of equals method with equal objects */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same values
         assertEquals(boolean1, boolean2);
 
@@ -131,21 +131,21 @@ public class ModifiableBooleanTest {
 
     /** Test of equals method with same object (reflexivity) */
     @Test
-    public void testEqualsSameObject() {
+    void testEqualsSameObject() {
         assertEquals(boolean1, boolean1);
         assertTrue(boolean1.equals(boolean1));
     }
 
     /** Test of equals method with null */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         assertNotEquals(null, boolean1);
         assertFalse(boolean1.equals(null));
     }
 
     /** Test of equals method with different class */
     @Test
-    public void testEqualsDifferentClass() {
+    void testEqualsDifferentClass() {
         // With Object
         assertNotEquals(boolean1, new Object());
         assertFalse(boolean1.equals(new Object()));
@@ -158,7 +158,7 @@ public class ModifiableBooleanTest {
 
     /** Test equals with transitivity property */
     @Test
-    public void testEqualsTransitivity() {
+    void testEqualsTransitivity() {
         ModifiableBoolean a = new ModifiableBoolean(Boolean.TRUE);
         ModifiableBoolean b = new ModifiableBoolean(Boolean.TRUE);
         ModifiableBoolean c = new ModifiableBoolean(Boolean.TRUE);
@@ -171,7 +171,7 @@ public class ModifiableBooleanTest {
 
     /** Test of equals method with modified values */
     @Test
-    public void testEqualsModifiedValues() {
+    void testEqualsModifiedValues() {
         BooleanToggleModification modification = new BooleanToggleModification();
         boolean1.addModification(modification);
         boolean2.addModification(modification);
@@ -198,7 +198,7 @@ public class ModifiableBooleanTest {
 
     /** Test equals with both null values */
     @Test
-    public void testEqualsWithNullValues() {
+    void testEqualsWithNullValues() {
         ModifiableBoolean nullBool1 = new ModifiableBoolean();
         ModifiableBoolean nullBool2 = new ModifiableBoolean();
 
@@ -220,7 +220,7 @@ public class ModifiableBooleanTest {
 
     /** Test equals with assertions */
     @Test
-    public void testEqualsWithAssertions() throws Exception {
+    void testEqualsWithAssertions() throws Exception {
         ModifiableBoolean bool1WithAssertion = new ModifiableBoolean(Boolean.TRUE);
         ModifiableBoolean bool2WithAssertion = new ModifiableBoolean(Boolean.TRUE);
 
@@ -242,7 +242,7 @@ public class ModifiableBooleanTest {
 
     /** Test of hashCode method for equal objects */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Equal objects should have equal hash codes
         assertEquals(boolean1.hashCode(), boolean2.hashCode());
 
@@ -265,7 +265,7 @@ public class ModifiableBooleanTest {
 
     /** Test of hashCode with null original value */
     @Test
-    public void testHashCodeWithNullValue() {
+    void testHashCodeWithNullValue() {
         ModifiableBoolean nullBool1 = new ModifiableBoolean();
         ModifiableBoolean nullBool2 = new ModifiableBoolean();
 
@@ -283,7 +283,7 @@ public class ModifiableBooleanTest {
 
     /** Test hashCode consistency with modifications */
     @Test
-    public void testHashCodeConsistencyWithModifications() {
+    void testHashCodeConsistencyWithModifications() {
         // Capture original hash code
         int originalHash = boolean1.hashCode();
 
@@ -310,14 +310,14 @@ public class ModifiableBooleanTest {
 
     /** Test of constructor with initial value */
     @Test
-    public void testConstructorWithValue() {
+    void testConstructorWithValue() {
         ModifiableBoolean booleanVar = new ModifiableBoolean(Boolean.TRUE);
         assertEquals(Boolean.TRUE, booleanVar.getOriginalValue());
     }
 
     /** Test of copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         BooleanToggleModification modification = new BooleanToggleModification();
         boolean1.addModification(modification);
 
@@ -329,7 +329,7 @@ public class ModifiableBooleanTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         BooleanToggleModification modification = new BooleanToggleModification();
         boolean1.addModification(modification);
 
@@ -342,7 +342,7 @@ public class ModifiableBooleanTest {
 
     /** Test of containsAssertion method */
     @Test
-    public void testContainsAssertion() throws Exception {
+    void testContainsAssertion() throws Exception {
         assertFalse(boolean1.containsAssertion());
 
         setAssertEquals(boolean1, Boolean.TRUE);

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayAppendValueModificationTest {
+class ByteArrayAppendValueModificationTest {
 
     private ByteArrayAppendValueModification b1;
     private ByteArrayAppendValueModification b2;
@@ -20,7 +20,7 @@ public class ByteArrayAppendValueModificationTest {
     private Object b4;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayAppendValueModification(new byte[] {0x01, 0x02, 0x03});
         b2 = new ByteArrayAppendValueModification(new byte[] {0x01, 0x02, 0x03});
         b3 = new ByteArrayAppendValueModification(new byte[] {0x04, 0x05, 0x06});
@@ -29,7 +29,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with a normal byte array
         byte[] input = new byte[] {0x10, 0x11, 0x12};
         byte[] expected = new byte[] {0x10, 0x11, 0x12, 0x01, 0x02, 0x03}; // Input + bytesToAppend
@@ -46,7 +46,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test of createCopy method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayAppendValueModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -55,7 +55,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ByteArrayAppendValueModification copy = new ByteArrayAppendValueModification(b1);
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -64,13 +64,13 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test of getBytesToAppend method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testGetBytesToAppend() {
+    void testGetBytesToAppend() {
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.getBytesToAppend());
     }
 
     /** Test of setBytesToAppend method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testSetBytesToAppend() {
+    void testSetBytesToAppend() {
         ByteArrayAppendValueModification mod =
                 new ByteArrayAppendValueModification(new byte[] {0x01, 0x02});
         mod.setBytesToAppend(new byte[] {0x0A, 0x0B, 0x0C});
@@ -79,7 +79,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test setBytesToAppend with null value */
     @Test
-    public void testSetBytesToAppendNull() {
+    void testSetBytesToAppendNull() {
         ByteArrayAppendValueModification mod =
                 new ByteArrayAppendValueModification(new byte[] {0x01, 0x02});
         assertThrows(NullPointerException.class, () -> mod.setBytesToAppend(null));
@@ -87,7 +87,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorNull() {
+    void testConstructorNull() {
         assertThrows(
                 NullPointerException.class,
                 () -> new ByteArrayAppendValueModification((byte[]) null));
@@ -95,14 +95,14 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test of hashCode method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode()); // Same values
         assertNotEquals(b1.hashCode(), b3.hashCode()); // Different values
     }
 
     /** Test of equals method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -121,7 +121,7 @@ public class ByteArrayAppendValueModificationTest {
 
     /** Test of toString method, of class ByteArrayAppendValueModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayAppendValueModification{bytesToAppend=01 02 03}";
         assertEquals(expected, b1.toString());
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayDeleteModificationTest {
+class ByteArrayDeleteModificationTest {
 
     private ByteArrayDeleteModification b1;
     private ByteArrayDeleteModification b2;
@@ -21,7 +21,7 @@ public class ByteArrayDeleteModificationTest {
     private Object differentType;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayDeleteModification(0, 0);
         b2 = new ByteArrayDeleteModification(0, 0);
         b3 = new ByteArrayDeleteModification(0, 1);
@@ -31,7 +31,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with normal byte array */
     @Test
-    public void testModifyImplementationHookNormal() {
+    void testModifyImplementationHookNormal() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         byte[] expected = new byte[] {1, 2, 3, 4};
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(0, 1);
@@ -40,7 +40,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with deletion in the middle */
     @Test
-    public void testModifyImplementationHookMiddle() {
+    void testModifyImplementationHookMiddle() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         byte[] expected = new byte[] {0, 1, 4};
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(2, 2);
@@ -49,7 +49,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with deletion at the end */
     @Test
-    public void testModifyImplementationHookEnd() {
+    void testModifyImplementationHookEnd() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         byte[] expected = new byte[] {0, 1, 2};
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(3, 2);
@@ -58,7 +58,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with zero count (no deletion) */
     @Test
-    public void testModifyImplementationHookZeroCount() {
+    void testModifyImplementationHookZeroCount() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(2, 0);
         assertArrayEquals(input, mod.modifyImplementationHook(input));
@@ -66,7 +66,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with negative count (should be treated as 0) */
     @Test
-    public void testModifyImplementationHookNegativeCount() {
+    void testModifyImplementationHookNegativeCount() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(2, -1);
         // Negative count should be treated as 0 due to Math.max(0, count)
@@ -75,7 +75,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with negative start position */
     @Test
-    public void testModifyImplementationHookNegativePosition() {
+    void testModifyImplementationHookNegativePosition() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         // -1 should wrap to position 3 (length-1 + position)
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(-1, 1);
@@ -85,7 +85,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with start position beyond array length */
     @Test
-    public void testModifyImplementationHookPositionBeyondLength() {
+    void testModifyImplementationHookPositionBeyondLength() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         // Position 10 should wrap to position 0 (10 % 5)
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(10, 2);
@@ -95,7 +95,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with count extending beyond array length */
     @Test
-    public void testModifyImplementationHookCountBeyondLength() {
+    void testModifyImplementationHookCountBeyondLength() {
         byte[] input = new byte[] {0, 1, 2, 3, 4};
         // Delete from position 3 with count 10 should delete to the end
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(3, 10);
@@ -105,14 +105,14 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of modifyImplementationHook method with null input */
     @Test
-    public void testModifyImplementationHookNullInput() {
+    void testModifyImplementationHookNullInput() {
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(0, 1);
         assertNull(mod.modifyImplementationHook(null));
     }
 
     /** Test of modifyImplementationHook method with empty array */
     @Test
-    public void testModifyImplementationHookEmptyArray() {
+    void testModifyImplementationHookEmptyArray() {
         byte[] emptyArray = new byte[0];
         ByteArrayDeleteModification mod = new ByteArrayDeleteModification(0, 1);
         assertArrayEquals(emptyArray, mod.modifyImplementationHook(emptyArray));
@@ -120,7 +120,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayDeleteModification original = new ByteArrayDeleteModification(2, 3);
         ByteArrayDeleteModification copy = original.createCopy();
 
@@ -139,7 +139,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ByteArrayDeleteModification original = new ByteArrayDeleteModification(2, 3);
         ByteArrayDeleteModification copy = new ByteArrayDeleteModification(original);
 
@@ -154,7 +154,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of getStartPosition method */
     @Test
-    public void testGetStartPosition() {
+    void testGetStartPosition() {
         assertEquals(0, b1.getStartPosition());
         assertEquals(0, b3.getStartPosition());
         assertEquals(1, b4.getStartPosition());
@@ -162,7 +162,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of setStartPosition method */
     @Test
-    public void testSetStartPosition() {
+    void testSetStartPosition() {
         b1.setStartPosition(5);
         assertEquals(5, b1.getStartPosition());
 
@@ -173,7 +173,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of getCount method */
     @Test
-    public void testGetCount() {
+    void testGetCount() {
         assertEquals(0, b1.getCount());
         assertEquals(1, b3.getCount());
         assertEquals(0, b4.getCount());
@@ -181,7 +181,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of setCount method */
     @Test
-    public void testSetCount() {
+    void testSetCount() {
         b1.setCount(10);
         assertEquals(10, b1.getCount());
 
@@ -192,25 +192,25 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of hashCode method with identical objects */
     @Test
-    public void testHashCodeIdentical() {
+    void testHashCodeIdentical() {
         assertEquals(b1.hashCode(), b2.hashCode());
     }
 
     /** Test of hashCode method with different count */
     @Test
-    public void testHashCodeDifferentCount() {
+    void testHashCodeDifferentCount() {
         assertNotEquals(b1.hashCode(), b3.hashCode());
     }
 
     /** Test of hashCode method with different position */
     @Test
-    public void testHashCodeDifferentPosition() {
+    void testHashCodeDifferentPosition() {
         assertNotEquals(b1.hashCode(), b4.hashCode());
     }
 
     /** Test of hashCode method consistency */
     @Test
-    public void testHashCodeConsistency() {
+    void testHashCodeConsistency() {
         int hash1 = b1.hashCode();
         int hash2 = b1.hashCode();
         assertEquals(hash1, hash2);
@@ -218,44 +218,44 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of equals method with same object reference */
     @Test
-    public void testEqualsSameReference() {
+    void testEqualsSameReference() {
         assertTrue(b1.equals(b1));
     }
 
     /** Test of equals method with equal objects */
     @Test
-    public void testEqualsEqualObjects() {
+    void testEqualsEqualObjects() {
         assertTrue(b1.equals(b2));
         assertTrue(b2.equals(b1)); // symmetry
     }
 
     /** Test of equals method with different count */
     @Test
-    public void testEqualsDifferentCount() {
+    void testEqualsDifferentCount() {
         assertFalse(b1.equals(b3));
     }
 
     /** Test of equals method with different position */
     @Test
-    public void testEqualsDifferentPosition() {
+    void testEqualsDifferentPosition() {
         assertFalse(b1.equals(b4));
     }
 
     /** Test of equals method with null */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         assertFalse(b1.equals(null));
     }
 
     /** Test of equals method with different type */
     @Test
-    public void testEqualsDifferentType() {
+    void testEqualsDifferentType() {
         assertFalse(b1.equals(differentType));
     }
 
     /** Test of equals method transitivity */
     @Test
-    public void testEqualsTransitivity() {
+    void testEqualsTransitivity() {
         ByteArrayDeleteModification a = new ByteArrayDeleteModification(5, 10);
         ByteArrayDeleteModification b = new ByteArrayDeleteModification(5, 10);
         ByteArrayDeleteModification c = new ByteArrayDeleteModification(5, 10);
@@ -267,7 +267,7 @@ public class ByteArrayDeleteModificationTest {
 
     /** Test of toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayDeleteModification{count=0, startPosition=0}";
         assertEquals(expected, b1.toString());
 

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModificationTest.java
@@ -12,14 +12,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayDuplicateModificationTest {
+class ByteArrayDuplicateModificationTest {
 
     private ByteArrayDuplicateModification b1;
     private ByteArrayDuplicateModification b2;
     private Object b3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayDuplicateModification();
         b2 = new ByteArrayDuplicateModification();
         b3 = new Object();
@@ -27,7 +27,7 @@ public class ByteArrayDuplicateModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayDuplicateModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with a normal byte array
         byte[] input = new byte[] {1, 2, 3, 4};
         byte[] expected = new byte[] {1, 2, 3, 4, 1, 2, 3, 4};
@@ -42,7 +42,7 @@ public class ByteArrayDuplicateModificationTest {
 
     /** Test of createCopy method, of class ByteArrayDuplicateModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayDuplicateModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -50,13 +50,13 @@ public class ByteArrayDuplicateModificationTest {
 
     /** Test of hashCode method, of class ByteArrayDuplicateModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode());
     }
 
     /** Test of equals method, of class ByteArrayDuplicateModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -72,7 +72,7 @@ public class ByteArrayDuplicateModificationTest {
 
     /** Test of toString method, of class ByteArrayDuplicateModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals(b1.toString(), b2.toString());
         assertEquals("ByteArrayDuplicateModification{}", b1.toString());
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayExplicitValueModificationTest {
+class ByteArrayExplicitValueModificationTest {
 
     private ByteArrayExplicitValueModification b1;
     private ByteArrayExplicitValueModification b2;
@@ -20,7 +20,7 @@ public class ByteArrayExplicitValueModificationTest {
     private Object b4;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayExplicitValueModification(new byte[] {0x01, 0x02, 0x03});
         b2 = new ByteArrayExplicitValueModification(new byte[] {0x01, 0x02, 0x03});
         b3 = new ByteArrayExplicitValueModification(new byte[] {0x04, 0x05, 0x06});
@@ -29,7 +29,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with any input, should always return explicit value
         byte[] input = new byte[] {0x10, 0x11, 0x12, 0x13};
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.modifyImplementationHook(input));
@@ -60,7 +60,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test of createCopy method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayExplicitValueModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -69,7 +69,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ByteArrayExplicitValueModification copy = new ByteArrayExplicitValueModification(b1);
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -78,13 +78,13 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test of getExplicitValue method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testGetExplicitValue() {
+    void testGetExplicitValue() {
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.getExplicitValue());
     }
 
     /** Test of setExplicitValue method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testSetExplicitValue() {
+    void testSetExplicitValue() {
         ByteArrayExplicitValueModification mod =
                 new ByteArrayExplicitValueModification(new byte[] {0x01, 0x02});
         mod.setExplicitValue(new byte[] {0x0A, 0x0B, 0x0C});
@@ -93,7 +93,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test setExplicitValue with null value */
     @Test
-    public void testSetExplicitValueNull() {
+    void testSetExplicitValueNull() {
         ByteArrayExplicitValueModification mod =
                 new ByteArrayExplicitValueModification(new byte[] {0x01, 0x02});
         assertThrows(NullPointerException.class, () -> mod.setExplicitValue(null));
@@ -101,7 +101,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorNull() {
+    void testConstructorNull() {
         assertThrows(
                 NullPointerException.class,
                 () -> new ByteArrayExplicitValueModification((byte[]) null));
@@ -109,14 +109,14 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test of hashCode method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode()); // Same explicit value
         assertNotEquals(b1.hashCode(), b3.hashCode()); // Different explicit value
     }
 
     /** Test of equals method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -135,7 +135,7 @@ public class ByteArrayExplicitValueModificationTest {
 
     /** Test of toString method, of class ByteArrayExplicitValueModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayExplicitValueModification{explicitValue=01 02 03}";
         assertEquals(expected, b1.toString());
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayInsertValueModificationTest {
+class ByteArrayInsertValueModificationTest {
 
     private ByteArrayInsertValueModification b1;
     private ByteArrayInsertValueModification b2;
@@ -21,7 +21,7 @@ public class ByteArrayInsertValueModificationTest {
     private Object b5;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayInsertValueModification(new byte[] {0x01, 0x02, 0x03}, 1);
         b2 = new ByteArrayInsertValueModification(new byte[] {0x01, 0x02, 0x03}, 1);
         b3 = new ByteArrayInsertValueModification(new byte[] {0x01, 0x02, 0x03}, 2);
@@ -31,7 +31,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test insert in the middle of array
         byte[] input = new byte[] {0x10, 0x11, 0x12, 0x13};
         byte[] expected = new byte[] {0x10, 0x01, 0x02, 0x03, 0x11, 0x12, 0x13};
@@ -77,7 +77,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of createCopy method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayInsertValueModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -87,7 +87,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ByteArrayInsertValueModification copy = new ByteArrayInsertValueModification(b1);
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -97,13 +97,13 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of getBytesToInsert method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testGetBytesToInsert() {
+    void testGetBytesToInsert() {
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.getBytesToInsert());
     }
 
     /** Test of setBytesToInsert method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testSetBytesToInsert() {
+    void testSetBytesToInsert() {
         ByteArrayInsertValueModification mod =
                 new ByteArrayInsertValueModification(new byte[] {0x01, 0x02}, 1);
         mod.setBytesToInsert(new byte[] {0x0A, 0x0B, 0x0C});
@@ -112,14 +112,14 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of getStartPosition method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testGetStartPosition() {
+    void testGetStartPosition() {
         assertEquals(1, b1.getStartPosition());
         assertEquals(2, b3.getStartPosition());
     }
 
     /** Test of setStartPosition method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testSetStartPosition() {
+    void testSetStartPosition() {
         ByteArrayInsertValueModification mod =
                 new ByteArrayInsertValueModification(new byte[] {0x01, 0x02}, 1);
         mod.setStartPosition(5);
@@ -128,7 +128,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test setBytesToInsert with null value */
     @Test
-    public void testSetBytesToInsertNull() {
+    void testSetBytesToInsertNull() {
         ByteArrayInsertValueModification mod =
                 new ByteArrayInsertValueModification(new byte[] {0x01, 0x02}, 1);
         assertThrows(NullPointerException.class, () -> mod.setBytesToInsert(null));
@@ -136,7 +136,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorNull() {
+    void testConstructorNull() {
         assertThrows(
                 NullPointerException.class,
                 () -> new ByteArrayInsertValueModification((byte[]) null, 1));
@@ -144,7 +144,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of hashCode method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode()); // Same values and position
         assertNotEquals(b1.hashCode(), b3.hashCode()); // Same values but different position
         assertNotEquals(b1.hashCode(), b4.hashCode()); // Different values but same position
@@ -152,7 +152,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of equals method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -174,7 +174,7 @@ public class ByteArrayInsertValueModificationTest {
 
     /** Test of toString method, of class ByteArrayInsertValueModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayInsertModification{bytesToInsert=01 02 03, startPosition=1}";
         assertEquals(expected, b1.toString());
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayPrependValueModificationTest {
+class ByteArrayPrependValueModificationTest {
 
     private ByteArrayPrependValueModification b1;
     private ByteArrayPrependValueModification b2;
@@ -20,7 +20,7 @@ public class ByteArrayPrependValueModificationTest {
     private Object b4;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayPrependValueModification(new byte[] {0x01, 0x02, 0x03});
         b2 = new ByteArrayPrependValueModification(new byte[] {0x01, 0x02, 0x03});
         b3 = new ByteArrayPrependValueModification(new byte[] {0x04, 0x05, 0x06});
@@ -29,7 +29,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with a normal byte array
         byte[] input = new byte[] {0x10, 0x11, 0x12};
         byte[] expected = new byte[] {0x01, 0x02, 0x03, 0x10, 0x11, 0x12}; // bytesToPrepend + Input
@@ -46,7 +46,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test of createCopy method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayPrependValueModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -55,7 +55,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ByteArrayPrependValueModification copy = new ByteArrayPrependValueModification(b1);
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -64,13 +64,13 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test of getBytesToPrepend method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testGetBytesToPrepend() {
+    void testGetBytesToPrepend() {
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.getBytesToPrepend());
     }
 
     /** Test of setBytesToPrepend method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testSetBytesToPrepend() {
+    void testSetBytesToPrepend() {
         ByteArrayPrependValueModification mod =
                 new ByteArrayPrependValueModification(new byte[] {0x01, 0x02});
         mod.setBytesToPrepend(new byte[] {0x0A, 0x0B, 0x0C});
@@ -79,7 +79,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test setBytesToPrepend with null value */
     @Test
-    public void testSetBytesToPrependNull() {
+    void testSetBytesToPrependNull() {
         ByteArrayPrependValueModification mod =
                 new ByteArrayPrependValueModification(new byte[] {0x01, 0x02});
         assertThrows(NullPointerException.class, () -> mod.setBytesToPrepend(null));
@@ -87,7 +87,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test constructor with null value */
     @Test
-    public void testConstructorNull() {
+    void testConstructorNull() {
         assertThrows(
                 NullPointerException.class,
                 () -> new ByteArrayPrependValueModification((byte[]) null));
@@ -95,14 +95,14 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test of hashCode method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode()); // Same values
         assertNotEquals(b1.hashCode(), b3.hashCode()); // Different values
     }
 
     /** Test of equals method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -121,7 +121,7 @@ public class ByteArrayPrependValueModificationTest {
 
     /** Test of toString method, of class ByteArrayPrependValueModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayPrependValueModification{bytesToPrepend=01 02 03}";
         assertEquals(expected, b1.toString());
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayShuffleModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayShuffleModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayShuffleModificationTest {
+class ByteArrayShuffleModificationTest {
 
     private ByteArrayShuffleModification b1;
     private ByteArrayShuffleModification b2;
@@ -20,7 +20,7 @@ public class ByteArrayShuffleModificationTest {
     private Object b4;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 =
                 new ByteArrayShuffleModification(
                         new int[] {0, 2, 1, 3}); // Swap positions 0 and 2, 1 and 3
@@ -31,7 +31,7 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test of modifyImplementationHook method with normal-sized array */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with array size <= 255
         byte[] input = new byte[] {0x10, 0x11, 0x12, 0x13};
 
@@ -53,7 +53,7 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test modifyImplementationHook with a large array (size > 255) */
     @Test
-    public void testModifyImplementationHookLargeArray() {
+    void testModifyImplementationHookLargeArray() {
         // Create a large array (> 255 bytes)
         byte[] largeArray = new byte[300];
         for (int i = 0; i < largeArray.length; i++) {
@@ -77,7 +77,7 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test of createCopy method, of class ByteArrayShuffleModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayShuffleModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -86,13 +86,13 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test of getShuffle method, of class ByteArrayShuffleModification. */
     @Test
-    public void testGetShuffle() {
+    void testGetShuffle() {
         assertArrayEquals(new int[] {0, 2, 1, 3}, b1.getShuffle());
     }
 
     /** Test of setShuffle method, of class ByteArrayShuffleModification. */
     @Test
-    public void testSetShuffle() {
+    void testSetShuffle() {
         ByteArrayShuffleModification mod = new ByteArrayShuffleModification(new int[] {1, 2, 3});
         mod.setShuffle(new int[] {5, 6, 7, 8});
         assertArrayEquals(new int[] {5, 6, 7, 8}, mod.getShuffle());
@@ -100,14 +100,14 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test of hashCode method, of class ByteArrayShuffleModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode());
         assertNotEquals(b1.hashCode(), b3.hashCode());
     }
 
     /** Test of equals method, of class ByteArrayShuffleModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -126,7 +126,7 @@ public class ByteArrayShuffleModificationTest {
 
     /** Test of toString method, of class ByteArrayShuffleModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayShuffleModification{shuffle=[0, 2, 1, 3]}";
         assertEquals(expected, b1.toString());
 

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModificationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArrayXorModificationTest {
+class ByteArrayXorModificationTest {
 
     private ByteArrayXorModification b1;
     private ByteArrayXorModification b2;
@@ -21,7 +21,7 @@ public class ByteArrayXorModificationTest {
     private Object b5;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         b1 = new ByteArrayXorModification(new byte[] {0x01, 0x02, 0x03}, 0);
         b2 = new ByteArrayXorModification(new byte[] {0x01, 0x02, 0x03}, 0);
         b3 = new ByteArrayXorModification(new byte[] {0x01, 0x02, 0x03}, 1);
@@ -31,7 +31,7 @@ public class ByteArrayXorModificationTest {
 
     /** Test of modifyImplementationHook method, of class ByteArrayXorModification. */
     @Test
-    public void testModifyImplementationHook() {
+    void testModifyImplementationHook() {
         // Test with a normal byte array
         byte[] input = new byte[] {0x10, 0x11, 0x12, 0x13};
         byte[] expected =
@@ -66,7 +66,7 @@ public class ByteArrayXorModificationTest {
 
     /** Test of createCopy method, of class ByteArrayXorModification. */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ByteArrayXorModification copy = b1.createCopy();
         assertNotSame(b1, copy);
         assertEquals(b1, copy);
@@ -76,13 +76,13 @@ public class ByteArrayXorModificationTest {
 
     /** Test of getXor method, of class ByteArrayXorModification. */
     @Test
-    public void testGetXor() {
+    void testGetXor() {
         assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, b1.getXor());
     }
 
     /** Test of setXor method, of class ByteArrayXorModification. */
     @Test
-    public void testSetXor() {
+    void testSetXor() {
         ByteArrayXorModification mod = new ByteArrayXorModification(new byte[] {0x01, 0x02}, 0);
         mod.setXor(new byte[] {0x0A, 0x0B});
         assertArrayEquals(new byte[] {0x0A, 0x0B}, mod.getXor());
@@ -90,14 +90,14 @@ public class ByteArrayXorModificationTest {
 
     /** Test of getStartPosition method, of class ByteArrayXorModification. */
     @Test
-    public void testGetStartPosition() {
+    void testGetStartPosition() {
         assertEquals(0, b1.getStartPosition());
         assertEquals(1, b3.getStartPosition());
     }
 
     /** Test of setStartPosition method, of class ByteArrayXorModification. */
     @Test
-    public void testSetStartPosition() {
+    void testSetStartPosition() {
         ByteArrayXorModification mod = new ByteArrayXorModification(new byte[] {0x01, 0x02}, 0);
         mod.setStartPosition(5);
         assertEquals(5, mod.getStartPosition());
@@ -105,7 +105,7 @@ public class ByteArrayXorModificationTest {
 
     /** Test of hashCode method, of class ByteArrayXorModification. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(b1.hashCode(), b2.hashCode());
         assertNotEquals(b1.hashCode(), b3.hashCode());
         assertNotEquals(b1.hashCode(), b4.hashCode());
@@ -113,7 +113,7 @@ public class ByteArrayXorModificationTest {
 
     /** Test of equals method, of class ByteArrayXorModification. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(b1, b1);
 
@@ -135,7 +135,7 @@ public class ByteArrayXorModificationTest {
 
     /** Test of toString method, of class ByteArrayXorModification. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ByteArrayXorModification{xor=01 02 03, startPosition=0}";
         assertEquals(expected, b1.toString());
 

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArrayTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArrayTest.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableByteArrayTest {
+class ModifiableByteArrayTest {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -32,7 +32,7 @@ public class ModifiableByteArrayTest {
     private byte[] modification2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         originalValue =
                 new byte[] {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6};
         modification1 = new byte[] {(byte) 2, (byte) 3};
@@ -47,7 +47,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setValue method, of class ModifiableByteArray. */
     @Test
-    public void testSetValue() {
+    void testSetValue() {
         LOGGER.info("testSetValue");
         ModifiableByteArray instance = new ModifiableByteArray();
         byte[] test = originalValue.clone();
@@ -57,7 +57,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setExplicitValue method, of class ModifiableByteArray. */
     @Test
-    public void testExplicitValue() {
+    void testExplicitValue() {
         LOGGER.info("testExplicitValue");
         VariableModification<byte[]> modifier =
                 new ByteArrayExplicitValueModification(modification1);
@@ -67,7 +67,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setXorFirstBytes method, of class ModifiableByteArray. */
     @Test
-    public void testXorFirstBytes() {
+    void testXorFirstBytes() {
         LOGGER.info("testXorFirstBytes");
         VariableModification<byte[]> modifier = new ByteArrayXorModification(modification1, 0);
         start.setModifications(modifier);
@@ -90,7 +90,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setXorLastBytes method, of class ModifiableByteArray. */
     @Test
-    public void testXorLastBytes() {
+    void testXorLastBytes() {
         LOGGER.info("testXorLastBytes");
 
         byte[] expResult = originalValue.clone();
@@ -118,7 +118,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setPrependBytes method, of class ModifiableByteArray. */
     @Test
-    public void testPrependBytes() {
+    void testPrependBytes() {
         LOGGER.info("testPrepend");
         int len = originalValue.length + modification1.length;
         byte[] expResult = new byte[len];
@@ -141,7 +141,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setAppendBytes method, of class ModifiableByteArray. */
     @Test
-    public void testAppendBytes() {
+    void testAppendBytes() {
         LOGGER.info("testAppendBytes");
         int len = originalValue.length + modification1.length;
         byte[] expResult = new byte[len];
@@ -164,7 +164,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setDeleteLastBytes method, of class ModifiableByteArray. */
     @Test
-    public void testDeleteLastBytes() {
+    void testDeleteLastBytes() {
         LOGGER.info("testDeleteLastBytes");
         // Deletes modification length many bytes
         assumeTrue(modification1.length < originalValue.length);
@@ -182,7 +182,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setDeleteFirstBytes method, of class ModifiableByteArray. */
     @Test
-    public void testDeleteFirstBytes() {
+    void testDeleteFirstBytes() {
         LOGGER.info("testDeleteFirstBytes");
         // Deletes modification length many bytes
         assumeTrue(modification1.length < originalValue.length);
@@ -202,7 +202,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setDeleteBytes method, of class ModifiableByteArray. */
     @Test
-    public void testDeleteBytes() {
+    void testDeleteBytes() {
         LOGGER.info("testDeleteBytes");
         // try to cover edge cases
         LOGGER.debug("Testing Delete all Bytes");
@@ -250,7 +250,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of setInsertBytes method, of class ModifiableByteArray. */
     @Test
-    public void testInsertBytes() {
+    void testInsertBytes() {
         LOGGER.info("testInsertBytes");
         // Insert at negative position -> wrap around
         assumeTrue(modification1.length < originalValue.length);
@@ -289,7 +289,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of add method, of class BigIntegerModificationFactory. */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         assertFalse(start.isOriginalValueModified());
         VariableModification<byte[]> modifier = new ByteArrayXorModification(new byte[] {}, 0);
         start.setModifications(modifier);
@@ -303,7 +303,7 @@ public class ModifiableByteArrayTest {
     }
 
     @Test
-    public void testDuplicateModification() {
+    void testDuplicateModification() {
         LOGGER.info("testDuplicateModification");
         byte[] expResult = ArrayConverter.concatenate(originalValue, originalValue);
 
@@ -317,7 +317,7 @@ public class ModifiableByteArrayTest {
 
     /** Test Shuffle */
     @Test
-    public void testShuffle() {
+    void testShuffle() {
         LOGGER.info("testShuffle");
         VariableModification<byte[]> modifier = new ByteArrayShuffleModification(new int[] {0, 1});
         start.setModifications(modifier);
@@ -336,7 +336,7 @@ public class ModifiableByteArrayTest {
     }
 
     @Test
-    public void toStringTest() {
+    void toStringTest() {
         ModifiableByteArray toTest = new ModifiableByteArray();
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -345,7 +345,7 @@ public class ModifiableByteArrayTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         ModifiableByteArray array1 = new ModifiableByteArray();
         array1.setOriginalValue(
                 new byte[] {
@@ -363,21 +363,21 @@ public class ModifiableByteArrayTest {
 
     /** Test equals with same object reference */
     @Test
-    public void testEqualsSameReference() {
+    void testEqualsSameReference() {
         ModifiableByteArray array = new ModifiableByteArray(new byte[] {1, 2, 3});
         assertTrue(array.equals(array));
     }
 
     /** Test equals with null */
     @Test
-    public void testEqualsNull() {
+    void testEqualsNull() {
         ModifiableByteArray array = new ModifiableByteArray(new byte[] {1, 2, 3});
         assertFalse(array.equals(null));
     }
 
     /** Test equals with different class */
     @Test
-    public void testEqualsDifferentClass() {
+    void testEqualsDifferentClass() {
         ModifiableByteArray array = new ModifiableByteArray(new byte[] {1, 2, 3});
         Object obj = new Object();
         assertFalse(array.equals(obj));
@@ -385,7 +385,7 @@ public class ModifiableByteArrayTest {
 
     /** Test equals with modified values producing same result */
     @Test
-    public void testEqualsModifiedSameValue() {
+    void testEqualsModifiedSameValue() {
         ModifiableByteArray array1 = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {0, 0, 0}, 0);
         array1.setModifications(xorMod);
@@ -400,7 +400,7 @@ public class ModifiableByteArrayTest {
 
     /** Test equals with modified values producing different results */
     @Test
-    public void testEqualsModifiedDifferentValue() {
+    void testEqualsModifiedDifferentValue() {
         ModifiableByteArray array1 = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {1, 0, 0}, 0);
         array1.setModifications(xorMod);
@@ -412,7 +412,7 @@ public class ModifiableByteArrayTest {
 
     /** Test equals with null values */
     @Test
-    public void testEqualsNullValues() {
+    void testEqualsNullValues() {
         ModifiableByteArray array1 = new ModifiableByteArray();
         ModifiableByteArray array2 = new ModifiableByteArray();
 
@@ -421,7 +421,7 @@ public class ModifiableByteArrayTest {
 
     /** Test hashCode method */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         ModifiableByteArray array1 = new ModifiableByteArray(new byte[] {1, 2, 3});
         ModifiableByteArray array2 = new ModifiableByteArray(new byte[] {1, 2, 3});
 
@@ -433,7 +433,7 @@ public class ModifiableByteArrayTest {
 
     /** Test hashCode with modified values */
     @Test
-    public void testHashCodeModified() {
+    void testHashCodeModified() {
         ModifiableByteArray array1 = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {1, 0, 0}, 0);
         array1.setModifications(xorMod);
@@ -445,7 +445,7 @@ public class ModifiableByteArrayTest {
 
     /** Test hashCode with null values */
     @Test
-    public void testHashCodeNull() {
+    void testHashCodeNull() {
         ModifiableByteArray array1 = new ModifiableByteArray();
         ModifiableByteArray array2 = new ModifiableByteArray();
 
@@ -454,7 +454,7 @@ public class ModifiableByteArrayTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         ModifiableByteArray original = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {1, 0, 0}, 0);
         original.setModifications(xorMod);
@@ -475,7 +475,7 @@ public class ModifiableByteArrayTest {
 
     /** Test copy constructor with assertions */
     @Test
-    public void testCopyConstructorWithAssertions() {
+    void testCopyConstructorWithAssertions() {
         ModifiableByteArray original = new ModifiableByteArray(new byte[] {1, 2, 3});
         original.setAssertEquals(new byte[] {0, 2, 3});
 
@@ -488,7 +488,7 @@ public class ModifiableByteArrayTest {
 
     /** Test createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ModifiableByteArray original = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {1, 0, 0}, 0);
         original.setModifications(xorMod);
@@ -505,7 +505,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of getAssertEquals method */
     @Test
-    public void testGetAssertEquals() {
+    void testGetAssertEquals() {
         byte[] assertValue = new byte[] {1, 2, 3};
         ModifiableByteArray array = new ModifiableByteArray();
         array.setAssertEquals(assertValue);
@@ -515,7 +515,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of validateAssertions method with matching values */
     @Test
-    public void testValidateAssertionsMatch() {
+    void testValidateAssertionsMatch() {
         byte[] originalValue = new byte[] {1, 2, 3};
         byte[] assertValue = new byte[] {1, 2, 3};
 
@@ -527,7 +527,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of validateAssertions method with non-matching values */
     @Test
-    public void testValidateAssertionsNoMatch() {
+    void testValidateAssertionsNoMatch() {
         byte[] originalValue = new byte[] {1, 2, 3};
         byte[] assertValue = new byte[] {3, 4, 5};
 
@@ -539,7 +539,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of validateAssertions method with no assertions */
     @Test
-    public void testValidateAssertionsNoAssertions() {
+    void testValidateAssertionsNoAssertions() {
         ModifiableByteArray array = new ModifiableByteArray(new byte[] {1, 2, 3});
 
         assertTrue(array.validateAssertions());
@@ -547,7 +547,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of isOriginalValueModified method with null original value */
     @Test
-    public void testIsOriginalValueModifiedNull() {
+    void testIsOriginalValueModifiedNull() {
         ModifiableByteArray array = new ModifiableByteArray();
 
         assertThrows(IllegalStateException.class, () -> array.isOriginalValueModified());
@@ -555,7 +555,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of toString method with null original value */
     @Test
-    public void testToStringNullOriginalValue() {
+    void testToStringNullOriginalValue() {
         ModifiableByteArray array = new ModifiableByteArray();
 
         assertEquals("ModifiableByteArray{originalValue=}", array.toString());
@@ -563,7 +563,7 @@ public class ModifiableByteArrayTest {
 
     /** Test of toString method with modifications */
     @Test
-    public void testToStringWithModifications() {
+    void testToStringWithModifications() {
         ModifiableByteArray array = new ModifiableByteArray(new byte[] {1, 2, 3});
         ByteArrayXorModification xorMod = new ByteArrayXorModification(new byte[] {1, 0, 0}, 0);
         array.setModifications(xorMod);

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerAddModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerAddModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerAddModificationTest {
+class IntegerAddModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testAddModification() {
+    void testAddModification() {
         int summand = 100;
         IntegerAddModification modification = new IntegerAddModification(summand);
         modifiableInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testAddZero() {
+    void testAddZero() {
         int summand = 0;
         IntegerAddModification modification = new IntegerAddModification(summand);
         modifiableInteger.setModifications(modification);
@@ -53,7 +53,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testAddNegative() {
+    void testAddNegative() {
         int summand = -50;
         IntegerAddModification modification = new IntegerAddModification(summand);
         modifiableInteger.setModifications(modification);
@@ -66,7 +66,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testAddWithNullInput() {
+    void testAddWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int summand = 100;
@@ -76,7 +76,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testAddMaxValue() {
+    void testAddMaxValue() {
         modifiableInteger.setOriginalValue(Integer.MAX_VALUE);
 
         int summand = 1;
@@ -91,7 +91,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testAddMinValue() {
+    void testAddMinValue() {
         modifiableInteger.setOriginalValue(Integer.MIN_VALUE);
 
         int summand = -1;
@@ -106,7 +106,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testGetSummand() {
+    void testGetSummand() {
         int summand = 42;
         IntegerAddModification modification = new IntegerAddModification(summand);
 
@@ -114,7 +114,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testSetSummand() {
+    void testSetSummand() {
         IntegerAddModification modification = new IntegerAddModification(10);
 
         int newSummand = 42;
@@ -124,7 +124,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int summand = 42;
         IntegerAddModification original = new IntegerAddModification(summand);
         IntegerAddModification copy = new IntegerAddModification(original);
@@ -133,7 +133,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int summand = 42;
         IntegerAddModification original = new IntegerAddModification(summand);
         IntegerAddModification copy = original.createCopy();
@@ -144,7 +144,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int summand1 = 42;
         int summand2 = 42;
         int summand3 = 100;
@@ -180,7 +180,7 @@ public class IntegerAddModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int summand = 42;
         IntegerAddModification modification = new IntegerAddModification(summand);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerExplicitValueModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerExplicitValueModificationTest {
+class IntegerExplicitValueModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testExplicitValueModification() {
+    void testExplicitValueModification() {
         int explicitValue = 999;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -41,7 +41,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testExplicitValueZero() {
+    void testExplicitValueZero() {
         int explicitValue = 0;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -54,7 +54,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testExplicitValueNegative() {
+    void testExplicitValueNegative() {
         int explicitValue = -500;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -67,7 +67,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testExplicitValueWithNullInput() {
+    void testExplicitValueWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int explicitValue = 999;
@@ -78,7 +78,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testExplicitValueMaxValue() {
+    void testExplicitValueMaxValue() {
         int explicitValue = Integer.MAX_VALUE;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -91,7 +91,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testExplicitValueMinValue() {
+    void testExplicitValueMinValue() {
         int explicitValue = Integer.MIN_VALUE;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -104,7 +104,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testGetExplicitValue() {
+    void testGetExplicitValue() {
         int explicitValue = 42;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);
@@ -113,7 +113,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testSetExplicitValue() {
+    void testSetExplicitValue() {
         IntegerExplicitValueModification modification = new IntegerExplicitValueModification(10);
 
         int newExplicitValue = 42;
@@ -123,7 +123,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int explicitValue = 42;
         IntegerExplicitValueModification original =
                 new IntegerExplicitValueModification(explicitValue);
@@ -133,7 +133,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int explicitValue = 42;
         IntegerExplicitValueModification original =
                 new IntegerExplicitValueModification(explicitValue);
@@ -145,7 +145,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int explicitValue1 = 42;
         int explicitValue2 = 42;
         int explicitValue3 = 100;
@@ -184,7 +184,7 @@ public class IntegerExplicitValueModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int explicitValue = 42;
         IntegerExplicitValueModification modification =
                 new IntegerExplicitValueModification(explicitValue);

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerMultiplyModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerMultiplyModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerMultiplyModificationTest {
+class IntegerMultiplyModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testMultiplyModification() {
+    void testMultiplyModification() {
         int factor = 2;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
         modifiableInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyByZero() {
+    void testMultiplyByZero() {
         int factor = 0;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
         modifiableInteger.setModifications(modification);
@@ -53,7 +53,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyByOne() {
+    void testMultiplyByOne() {
         int factor = 1;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
         modifiableInteger.setModifications(modification);
@@ -65,7 +65,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyByNegative() {
+    void testMultiplyByNegative() {
         int factor = -1;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
         modifiableInteger.setModifications(modification);
@@ -77,7 +77,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyWithNullInput() {
+    void testMultiplyWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int factor = 5;
@@ -87,7 +87,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyMaxValue() {
+    void testMultiplyMaxValue() {
         modifiableInteger.setOriginalValue(Integer.MAX_VALUE);
 
         int factor = 2;
@@ -101,7 +101,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testMultiplyMinValue() {
+    void testMultiplyMinValue() {
         modifiableInteger.setOriginalValue(Integer.MIN_VALUE);
 
         int factor = 2;
@@ -115,7 +115,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testGetFactor() {
+    void testGetFactor() {
         int factor = 5;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
 
@@ -123,7 +123,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testSetFactor() {
+    void testSetFactor() {
         IntegerMultiplyModification modification = new IntegerMultiplyModification(2);
 
         int newFactor = 10;
@@ -133,7 +133,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int factor = 7;
         IntegerMultiplyModification original = new IntegerMultiplyModification(factor);
         IntegerMultiplyModification copy = new IntegerMultiplyModification(original);
@@ -142,7 +142,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int factor = 7;
         IntegerMultiplyModification original = new IntegerMultiplyModification(factor);
         IntegerMultiplyModification copy = original.createCopy();
@@ -157,7 +157,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int factor1 = 5;
         int factor2 = 5;
         int factor3 = 10;
@@ -190,7 +190,7 @@ public class IntegerMultiplyModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int factor = 42;
         IntegerMultiplyModification modification = new IntegerMultiplyModification(factor);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftLeftModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftLeftModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerShiftLeftModificationTest {
+class IntegerShiftLeftModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123456;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testShiftLeftModification() {
+    void testShiftLeftModification() {
         int shift = 4;
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -40,7 +40,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithZeroShift() {
+    void testShiftLeftWithZeroShift() {
         int shift = 0;
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -52,7 +52,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithMaxShift() {
+    void testShiftLeftWithMaxShift() {
         int shift = 31; // Max shift for int is 31 bits
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -64,7 +64,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithNullInput() {
+    void testShiftLeftWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int shift = 4;
@@ -75,7 +75,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testShiftLeftGetterAndSetter() {
+    void testShiftLeftGetterAndSetter() {
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(5);
 
         int shift = 15;
@@ -85,7 +85,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int shift = 7;
         IntegerShiftLeftModification original = new IntegerShiftLeftModification(shift);
         IntegerShiftLeftModification copy = new IntegerShiftLeftModification(original);
@@ -95,7 +95,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int shift = 7;
         IntegerShiftLeftModification original = new IntegerShiftLeftModification(shift);
         IntegerShiftLeftModification copy = original.createCopy();
@@ -106,7 +106,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int shift1 = 5;
         int shift2 = 5;
         int shift3 = 10;
@@ -140,7 +140,7 @@ public class IntegerShiftLeftModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int shift = 42;
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftModificationTest.java
@@ -14,20 +14,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerShiftModificationTest {
+class IntegerShiftModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123456;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testShiftLeftModification() {
+    void testShiftLeftModification() {
         int shift = 4;
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -39,7 +39,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithZeroShift() {
+    void testShiftLeftWithZeroShift() {
         int shift = 0;
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -51,7 +51,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithMaxShift() {
+    void testShiftLeftWithMaxShift() {
         int shift = 31; // Max shift for int is 31 bits
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(shift);
         modifiableInteger.setModifications(modification);
@@ -63,7 +63,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithNullInput() {
+    void testShiftLeftWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int shift = 4;
@@ -74,7 +74,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftLeftEqualsAndHashCode() {
+    void testShiftLeftEqualsAndHashCode() {
         int shift = 10;
         IntegerShiftLeftModification modification1 = new IntegerShiftLeftModification(shift);
         IntegerShiftLeftModification modification2 = new IntegerShiftLeftModification(shift);
@@ -90,7 +90,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftLeftGetterAndSetter() {
+    void testShiftLeftGetterAndSetter() {
         IntegerShiftLeftModification modification = new IntegerShiftLeftModification(5);
 
         int shift = 15;
@@ -100,7 +100,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightModification() {
+    void testShiftRightModification() {
         int shift = 4;
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -112,7 +112,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNegativeNumber() {
+    void testShiftRightWithNegativeNumber() {
         int negativeValue = -98765;
         modifiableInteger.setOriginalValue(negativeValue);
 
@@ -127,7 +127,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightWithZeroShift() {
+    void testShiftRightWithZeroShift() {
         int shift = 0;
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -139,7 +139,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightWithMaxShift() {
+    void testShiftRightWithMaxShift() {
         int shift = 31; // Max shift for int is 31 bits
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -151,7 +151,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNullInput() {
+    void testShiftRightWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int shift = 4;
@@ -161,7 +161,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightEqualsAndHashCode() {
+    void testShiftRightEqualsAndHashCode() {
         int shift = 10;
         IntegerShiftRightModification modification1 = new IntegerShiftRightModification(shift);
         IntegerShiftRightModification modification2 = new IntegerShiftRightModification(shift);
@@ -177,7 +177,7 @@ public class IntegerShiftModificationTest {
     }
 
     @Test
-    public void testShiftRightGetterAndSetter() {
+    void testShiftRightGetterAndSetter() {
         IntegerShiftRightModification modification = new IntegerShiftRightModification(5);
 
         int shift = 15;

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftRightModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerShiftRightModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerShiftRightModificationTest {
+class IntegerShiftRightModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123456;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testShiftRightModification() {
+    void testShiftRightModification() {
         int shift = 4;
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -40,7 +40,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNegativeNumber() {
+    void testShiftRightWithNegativeNumber() {
         int negativeValue = -98765;
         modifiableInteger.setOriginalValue(negativeValue);
 
@@ -55,7 +55,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithZeroShift() {
+    void testShiftRightWithZeroShift() {
         int shift = 0;
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -67,7 +67,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithMaxShift() {
+    void testShiftRightWithMaxShift() {
         int shift = 31; // Max shift for int is 31 bits
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         modifiableInteger.setModifications(modification);
@@ -79,7 +79,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNullInput() {
+    void testShiftRightWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int shift = 4;
@@ -89,7 +89,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testShiftRightGetterAndSetter() {
+    void testShiftRightGetterAndSetter() {
         IntegerShiftRightModification modification = new IntegerShiftRightModification(5);
 
         int shift = 15;
@@ -99,7 +99,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int shift = 7;
         IntegerShiftRightModification original = new IntegerShiftRightModification(shift);
         IntegerShiftRightModification copy = new IntegerShiftRightModification(original);
@@ -109,7 +109,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int shift = 7;
         IntegerShiftRightModification original = new IntegerShiftRightModification(shift);
         IntegerShiftRightModification copy = original.createCopy();
@@ -120,7 +120,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int shift1 = 5;
         int shift2 = 5;
         int shift3 = 10;
@@ -154,7 +154,7 @@ public class IntegerShiftRightModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int shift = 42;
         IntegerShiftRightModification modification = new IntegerShiftRightModification(shift);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerSubtractModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerSubtractModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerSubtractModificationTest {
+class IntegerSubtractModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123;
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testSubtractModification() {
+    void testSubtractModification() {
         int subtrahend = 50;
         IntegerSubtractModification modification = new IntegerSubtractModification(subtrahend);
         modifiableInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSubtractZero() {
+    void testSubtractZero() {
         int subtrahend = 0;
         IntegerSubtractModification modification = new IntegerSubtractModification(subtrahend);
         modifiableInteger.setModifications(modification);
@@ -53,7 +53,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSubtractNegative() {
+    void testSubtractNegative() {
         int subtrahend = -25;
         IntegerSubtractModification modification = new IntegerSubtractModification(subtrahend);
         modifiableInteger.setModifications(modification);
@@ -66,7 +66,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSubtractWithNullInput() {
+    void testSubtractWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int subtrahend = 50;
@@ -76,7 +76,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSubtractMinValue() {
+    void testSubtractMinValue() {
         modifiableInteger.setOriginalValue(Integer.MIN_VALUE);
 
         int subtrahend = 1;
@@ -91,7 +91,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSubtractMaxValue() {
+    void testSubtractMaxValue() {
         modifiableInteger.setOriginalValue(Integer.MAX_VALUE);
 
         int subtrahend = -1;
@@ -106,7 +106,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testGetSubtrahend() {
+    void testGetSubtrahend() {
         int subtrahend = 42;
         IntegerSubtractModification modification = new IntegerSubtractModification(subtrahend);
 
@@ -114,7 +114,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testSetSubtrahend() {
+    void testSetSubtrahend() {
         IntegerSubtractModification modification = new IntegerSubtractModification(10);
 
         int newSubtrahend = 42;
@@ -124,7 +124,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int subtrahend = 42;
         IntegerSubtractModification original = new IntegerSubtractModification(subtrahend);
         IntegerSubtractModification copy = new IntegerSubtractModification(original);
@@ -133,7 +133,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int subtrahend = 42;
         IntegerSubtractModification original = new IntegerSubtractModification(subtrahend);
         IntegerSubtractModification copy = original.createCopy();
@@ -144,7 +144,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int subtrahend1 = 42;
         int subtrahend2 = 42;
         int subtrahend3 = 100;
@@ -179,7 +179,7 @@ public class IntegerSubtractModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int subtrahend = 42;
         IntegerSubtractModification modification = new IntegerSubtractModification(subtrahend);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerXorModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/integer/IntegerXorModificationTest.java
@@ -15,20 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IntegerXorModificationTest {
+class IntegerXorModificationTest {
 
     private ModifiableInteger modifiableInteger;
     private int originalValue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableInteger = new ModifiableInteger();
         originalValue = 123; // 01111011 in binary
         modifiableInteger.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testXorModification() {
+    void testXorModification() {
         int xor = 42; // 00101010 in binary
         IntegerXorModification modification = new IntegerXorModification(xor);
         modifiableInteger.setModifications(modification);
@@ -41,7 +41,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorZero() {
+    void testXorZero() {
         int xor = 0;
         IntegerXorModification modification = new IntegerXorModification(xor);
         modifiableInteger.setModifications(modification);
@@ -53,7 +53,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorSelf() {
+    void testXorSelf() {
         int xor = originalValue;
         IntegerXorModification modification = new IntegerXorModification(xor);
         modifiableInteger.setModifications(modification);
@@ -65,7 +65,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorAllBitsSet() {
+    void testXorAllBitsSet() {
         int xor = -1; // All bits set to 1
         IntegerXorModification modification = new IntegerXorModification(xor);
         modifiableInteger.setModifications(modification);
@@ -77,7 +77,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorIdempotent() {
+    void testXorIdempotent() {
         int xor = 42;
         IntegerXorModification modification1 = new IntegerXorModification(xor);
         IntegerXorModification modification2 = new IntegerXorModification(xor);
@@ -91,7 +91,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorWithNullInput() {
+    void testXorWithNullInput() {
         modifiableInteger.setOriginalValue(null);
 
         int xor = 42;
@@ -101,7 +101,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorMinValue() {
+    void testXorMinValue() {
         modifiableInteger.setOriginalValue(Integer.MIN_VALUE);
 
         int xor = 1; // Flip the sign bit
@@ -115,7 +115,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testXorMaxValue() {
+    void testXorMaxValue() {
         modifiableInteger.setOriginalValue(Integer.MAX_VALUE);
 
         int xor = 1;
@@ -129,7 +129,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testGetXor() {
+    void testGetXor() {
         int xor = 42;
         IntegerXorModification modification = new IntegerXorModification(xor);
 
@@ -137,7 +137,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testSetXor() {
+    void testSetXor() {
         IntegerXorModification modification = new IntegerXorModification(10);
 
         int newXor = 42;
@@ -147,7 +147,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         int xor = 42;
         IntegerXorModification original = new IntegerXorModification(xor);
         IntegerXorModification copy = new IntegerXorModification(original);
@@ -156,7 +156,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         int xor = 42;
         IntegerXorModification original = new IntegerXorModification(xor);
         IntegerXorModification copy = original.createCopy();
@@ -167,7 +167,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         int xor1 = 42;
         int xor2 = 42;
         int xor3 = 100;
@@ -200,7 +200,7 @@ public class IntegerXorModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         int xor = 42;
         IntegerXorModification modification = new IntegerXorModification(xor);
         String toString = modification.toString();

--- a/src/test/java/de/rub/nds/modifiablevariable/length/ModifiableLengthFieldTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/length/ModifiableLengthFieldTest.java
@@ -14,14 +14,14 @@ import de.rub.nds.modifiablevariable.integer.IntegerAddModification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableLengthFieldTest {
+class ModifiableLengthFieldTest {
 
     private ModifiableLengthField lengthField1;
     private ModifiableLengthField lengthField2;
     private ModifiableByteArray array;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         array = new ModifiableByteArray();
         array.setOriginalValue(new byte[] {0, 1, 2, 3});
         lengthField1 = new ModifiableLengthField(array);
@@ -30,7 +30,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test of getOriginalValue method, of class ModifiableLengthField. */
     @Test
-    public void testGetOriginalValue() {
+    void testGetOriginalValue() {
         // Test the initial original value
         assertEquals(4, (int) lengthField1.getOriginalValue());
         assertEquals(
@@ -71,13 +71,13 @@ public class ModifiableLengthFieldTest {
 
     /** Test of setOriginalValue method, of class ModifiableLengthField. */
     @Test
-    public void testSetOriginalValue() {
+    void testSetOriginalValue() {
         assertThrows(UnsupportedOperationException.class, () -> lengthField1.setOriginalValue(4));
     }
 
     /** Test of toString method, of class ModifiableLengthField. */
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals(lengthField1.toString(), lengthField2.toString());
 
         array = new ModifiableByteArray();
@@ -93,7 +93,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test of copy constructor and createCopy method. */
     @Test
-    public void testCopyConstructorAndCreateCopy() {
+    void testCopyConstructorAndCreateCopy() {
         // Test copy constructor
         ModifiableLengthField copy1 = new ModifiableLengthField(lengthField1);
         assertEquals(lengthField1.getValue(), copy1.getValue());
@@ -124,7 +124,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test of equals method, of class ModifiableLengthField. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Same object reference
         assertEquals(lengthField1, lengthField1, "Object should equal itself");
 
@@ -190,7 +190,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test of hashCode method, of class ModifiableLengthField. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Same hashCode for equal objects (same reference, same value)
         assertEquals(
                 lengthField1.hashCode(),
@@ -246,7 +246,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test null reference in constructor */
     @Test
-    public void testNullReference() {
+    void testNullReference() {
         ModifiableByteArray nullArray = null;
         // The constructor should throw NullPointerException with null reference
         assertThrows(
@@ -257,7 +257,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test equality with different length fields */
     @Test
-    public void testEqualityWithDifferentLengthFields() {
+    void testEqualityWithDifferentLengthFields() {
         // Two length fields with different byte arrays but same length
         ModifiableByteArray array1 = new ModifiableByteArray();
         array1.setOriginalValue(new byte[] {0, 1, 2, 3});
@@ -311,7 +311,7 @@ public class ModifiableLengthFieldTest {
      * behavior that fields with same values but different references are not equal.
      */
     @Test
-    public void testReferenceEqualityBehavior() {
+    void testReferenceEqualityBehavior() {
         // Create two byte arrays with identical content
         ModifiableByteArray array1 = new ModifiableByteArray();
         array1.setOriginalValue(new byte[] {1, 2, 3, 4});
@@ -357,10 +357,10 @@ public class ModifiableLengthFieldTest {
 
     /** Test equals and hashCode with null values */
     @Test
-    public void testEqualsAndHashCodeWithNullValues() {
+    void testEqualsAndHashCodeWithNullValues() {
         // Create a special modification that returns null regardless of input
         class NullModification extends IntegerAddModification {
-            public NullModification() {
+            NullModification() {
                 super(0);
             }
 
@@ -456,7 +456,7 @@ public class ModifiableLengthFieldTest {
      * nature of ModifiableLengthField's equality based on the state of the referenced array.
      */
     @Test
-    public void testEqualityWithChangingReference() {
+    void testEqualityWithChangingReference() {
         // Create a shared array reference
         ModifiableByteArray sharedArray = new ModifiableByteArray();
         sharedArray.setOriginalValue(new byte[] {1, 2, 3, 4});
@@ -506,7 +506,7 @@ public class ModifiableLengthFieldTest {
 
     /** Test with reference having no original value */
     @Test
-    public void testReferenceWithNoOriginalValue() {
+    void testReferenceWithNoOriginalValue() {
         // Create a byte array reference but don't set an original value
         ModifiableByteArray emptyRef = new ModifiableByteArray();
         // emptyRef.setOriginalValue() not called

--- a/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
@@ -507,7 +507,7 @@ class ExtendedPatternLayoutTest {
     private static class SimpleTestPatternSelector implements PatternSelector {
         private final String name;
 
-        public SimpleTestPatternSelector(String name) {
+        SimpleTestPatternSelector(String name) {
             this.name = name;
         }
 

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongAddModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongAddModificationTest.java
@@ -18,18 +18,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongAddModificationTest {
+class LongAddModificationTest {
 
     private LongAddModification modification;
     private final Long summand = 5L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongAddModification(summand);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongAddModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -38,7 +38,7 @@ public class LongAddModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongAddModification equalModification = new LongAddModification(summand);
         LongAddModification differentModification = new LongAddModification(10L);
 
@@ -58,7 +58,7 @@ public class LongAddModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongAddModification equalModification = new LongAddModification(summand);
 
         // Equal objects should have equal hash codes
@@ -66,25 +66,25 @@ public class LongAddModificationTest {
     }
 
     @Test
-    public void testGetSummand() {
+    void testGetSummand() {
         assertEquals(summand, modification.getSummand());
     }
 
     @Test
-    public void testSetSummand() {
+    void testSetSummand() {
         Long newSummand = 20L;
         modification.setSummand(newSummand);
         assertEquals(newSummand, modification.getSummand());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongAddModification{summand=5}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongAddModification constructor = new LongAddModification(5L);
         assertNotNull(constructor);
         assertEquals(constructor.getSummand(), 5);
@@ -98,7 +98,7 @@ public class LongAddModificationTest {
     // but we can indirectly test its behavior through public methods
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongExplicitValueModificationTest.java
@@ -18,18 +18,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongExplicitValueModificationTest {
+class LongExplicitValueModificationTest {
 
     private LongExplicitValueModification modification;
     private final Long explicitValue = 42L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongExplicitValueModification(explicitValue);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongExplicitValueModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -38,7 +38,7 @@ public class LongExplicitValueModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongExplicitValueModification equalModification =
                 new LongExplicitValueModification(explicitValue);
         LongExplicitValueModification differentModification =
@@ -60,7 +60,7 @@ public class LongExplicitValueModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongExplicitValueModification equalModification =
                 new LongExplicitValueModification(explicitValue);
 
@@ -69,25 +69,25 @@ public class LongExplicitValueModificationTest {
     }
 
     @Test
-    public void testGetExplicitValue() {
+    void testGetExplicitValue() {
         assertEquals(explicitValue, modification.getExplicitValue());
     }
 
     @Test
-    public void testSetExplicitValue() {
+    void testSetExplicitValue() {
         Long newValue = 20L;
         modification.setExplicitValue(newValue);
         assertEquals(newValue, modification.getExplicitValue());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongExplicitValueModification{explicitValue=42}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         // Test default constructor
         LongExplicitValueModification constructor = new LongExplicitValueModification(5L);
         assertNotNull(constructor);
@@ -102,7 +102,7 @@ public class LongExplicitValueModificationTest {
     // but we can indirectly test its behavior through public methods
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongModificationFactoryTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongModificationFactoryTest.java
@@ -22,10 +22,10 @@ import de.rub.nds.modifiablevariable.longint.LongSwapEndianModification;
 import de.rub.nds.modifiablevariable.longint.LongXorModification;
 import org.junit.jupiter.api.Test;
 
-public class LongModificationFactoryTest {
+class LongModificationFactoryTest {
 
     @Test
-    public void testAddWithLong() {
+    void testAddWithLong() {
         Long summand = 10L;
         VariableModification<Long> modification = new LongAddModification(summand);
 
@@ -35,7 +35,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testSubWithLong() {
+    void testSubWithLong() {
         Long subtrahend = 10L;
         VariableModification<Long> modification = new LongSubtractModification(subtrahend);
 
@@ -45,7 +45,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testXorWithLong() {
+    void testXorWithLong() {
         Long xorValue = 10L;
         VariableModification<Long> modification = new LongXorModification(xorValue);
 
@@ -55,7 +55,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testSwapEndian() {
+    void testSwapEndian() {
         VariableModification<Long> modification = new LongSwapEndianModification();
 
         assertNotNull(modification);
@@ -63,7 +63,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testExplicitValueWithLong() {
+    void testExplicitValueWithLong() {
         Long explicitValue = 10L;
         VariableModification<Long> modification = new LongExplicitValueModification(explicitValue);
 
@@ -74,7 +74,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testMultiply() {
+    void testMultiply() {
         Long factor = 10L;
         VariableModification<Long> modification = new LongMultiplyModification(factor);
 
@@ -84,7 +84,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testShiftLeft() {
+    void testShiftLeft() {
         int shift = 5;
         VariableModification<Long> modification = new LongShiftLeftModification(shift);
 
@@ -94,7 +94,7 @@ public class LongModificationFactoryTest {
     }
 
     @Test
-    public void testShiftRight() {
+    void testShiftRight() {
         int shift = 5;
         VariableModification<Long> modification = new LongShiftRightModification(shift);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongModificationTest.java
@@ -23,14 +23,14 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongModificationTest {
+class LongModificationTest {
 
     private ModifiableLong start;
 
     private Long expectedResult, result;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         start = new ModifiableLong();
         start.setOriginalValue(10L);
         expectedResult = null;
@@ -38,7 +38,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testAdd() {
+    void testAdd() {
 
         VariableModification<Long> modifier = new LongAddModification(1L);
         start.setModifications(modifier);
@@ -49,7 +49,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testSub() {
+    void testSub() {
         VariableModification<Long> modifier = new LongSubtractModification(1L);
         start.setModifications(modifier);
         expectedResult = 9L;
@@ -59,7 +59,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testXor() {
+    void testXor() {
         VariableModification<Long> modifier = new LongXorModification(2L);
         start.setModifications(modifier);
         expectedResult = 8L;
@@ -69,7 +69,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testExplicitValue() {
+    void testExplicitValue() {
         VariableModification<Long> modifier = new LongExplicitValueModification(7L);
         start.setModifications(modifier);
         expectedResult = 7L;
@@ -79,7 +79,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testMultiply() {
+    void testMultiply() {
         VariableModification<Long> modifier = new LongMultiplyModification(3L);
         start.setModifications(modifier);
         expectedResult = 30L;
@@ -89,7 +89,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testMultiplyWithZero() {
+    void testMultiplyWithZero() {
         VariableModification<Long> modifier = new LongMultiplyModification(0L);
         start.setModifications(modifier);
         expectedResult = 0L;
@@ -99,7 +99,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testMultiplyWithNull() {
+    void testMultiplyWithNull() {
         ModifiableLong nullStart = new ModifiableLong();
         VariableModification<Long> modifier = new LongMultiplyModification(5L);
         nullStart.setModifications(modifier);
@@ -107,7 +107,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftLeft() {
+    void testShiftLeft() {
         VariableModification<Long> modifier = new LongShiftLeftModification(2);
         start.setModifications(modifier);
         expectedResult = 40L; // 10 << 2 = 40
@@ -117,7 +117,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithLargeShift() {
+    void testShiftLeftWithLargeShift() {
         VariableModification<Long> modifier = new LongShiftLeftModification(65);
         start.setModifications(modifier);
         expectedResult = 20L; // (10 << 65) % 64 = (10 << 1) = 20
@@ -127,7 +127,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftLeftWithNull() {
+    void testShiftLeftWithNull() {
         ModifiableLong nullStart = new ModifiableLong();
         VariableModification<Long> modifier = new LongShiftLeftModification(2);
         nullStart.setModifications(modifier);
@@ -135,7 +135,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftRight() {
+    void testShiftRight() {
         start.setOriginalValue(40L);
         VariableModification<Long> modifier = new LongShiftRightModification(2);
         start.setModifications(modifier);
@@ -146,7 +146,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftRightWithLargeShift() {
+    void testShiftRightWithLargeShift() {
         start.setOriginalValue(40L);
         VariableModification<Long> modifier = new LongShiftRightModification(66);
         start.setModifications(modifier);
@@ -157,7 +157,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testShiftRightWithNull() {
+    void testShiftRightWithNull() {
         ModifiableLong nullStart = new ModifiableLong();
         VariableModification<Long> modifier = new LongShiftRightModification(2);
         nullStart.setModifications(modifier);
@@ -167,7 +167,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testSwapEndian() {
+    void testSwapEndian() {
         start.setOriginalValue(0x1122334455667788L);
         VariableModification<Long> modifier = new LongSwapEndianModification();
         start.setModifications(modifier);
@@ -178,7 +178,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testSwapEndianWithNull() {
+    void testSwapEndianWithNull() {
         ModifiableLong nullStart = new ModifiableLong();
         VariableModification<Long> modifier = new LongSwapEndianModification();
         nullStart.setModifications(modifier);
@@ -186,7 +186,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testMultipleModifications() {
+    void testMultipleModifications() {
         // Test add followed by multiply
         VariableModification<Long> addModifier = new LongAddModification(5L);
         VariableModification<Long> multiplyModifier = new LongMultiplyModification(2L);
@@ -199,7 +199,7 @@ public class LongModificationTest {
     }
 
     @Test
-    public void testBoundaryValues() {
+    void testBoundaryValues() {
         // Test with Long.MAX_VALUE
         start.setOriginalValue(Long.MAX_VALUE);
         VariableModification<Long> addModifier = new LongAddModification(1L);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongMultiplyModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongMultiplyModificationTest.java
@@ -18,18 +18,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongMultiplyModificationTest {
+class LongMultiplyModificationTest {
 
     private LongMultiplyModification modification;
     private final Long factor = 5L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongMultiplyModification(factor);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongMultiplyModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -38,7 +38,7 @@ public class LongMultiplyModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongMultiplyModification equalModification = new LongMultiplyModification(factor);
         LongMultiplyModification differentModification = new LongMultiplyModification(10L);
 
@@ -58,7 +58,7 @@ public class LongMultiplyModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongMultiplyModification equalModification = new LongMultiplyModification(factor);
 
         // Equal objects should have equal hash codes
@@ -66,25 +66,25 @@ public class LongMultiplyModificationTest {
     }
 
     @Test
-    public void testGetFactor() {
+    void testGetFactor() {
         assertEquals(factor, modification.getFactor());
     }
 
     @Test
-    public void testSetFactor() {
+    void testSetFactor() {
         Long newFactor = 20L;
         modification.setFactor(newFactor);
         assertEquals(newFactor, modification.getFactor());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongMultiplyModification{factor=5}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongMultiplyModification constructor = new LongMultiplyModification(5L);
         assertNotNull(constructor);
         assertEquals(5L, constructor.getFactor());
@@ -95,7 +95,7 @@ public class LongMultiplyModificationTest {
     }
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongShiftLeftModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongShiftLeftModificationTest.java
@@ -17,18 +17,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongShiftLeftModificationTest {
+class LongShiftLeftModificationTest {
 
     private LongShiftLeftModification modification;
     private final int shift = 3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongShiftLeftModification(shift);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongShiftLeftModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -36,7 +36,7 @@ public class LongShiftLeftModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongShiftLeftModification equalModification = new LongShiftLeftModification(shift);
         LongShiftLeftModification differentModification = new LongShiftLeftModification(10);
 
@@ -56,7 +56,7 @@ public class LongShiftLeftModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongShiftLeftModification equalModification = new LongShiftLeftModification(shift);
 
         // Equal objects should have equal hash codes
@@ -64,25 +64,25 @@ public class LongShiftLeftModificationTest {
     }
 
     @Test
-    public void testGetShift() {
+    void testGetShift() {
         assertEquals(shift, modification.getShift());
     }
 
     @Test
-    public void testSetShift() {
+    void testSetShift() {
         int newShift = 20;
         modification.setShift(newShift);
         assertEquals(newShift, modification.getShift());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongShiftLeftModification{shift=3}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongShiftLeftModification constructor = new LongShiftLeftModification(5);
         assertNotNull(constructor);
         assertEquals(5, constructor.getShift());
@@ -93,7 +93,7 @@ public class LongShiftLeftModificationTest {
     }
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongShiftRightModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongShiftRightModificationTest.java
@@ -18,18 +18,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongShiftRightModificationTest {
+class LongShiftRightModificationTest {
 
     private LongShiftRightModification modification;
     private final int shift = 3;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongShiftRightModification(shift);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongShiftRightModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -38,7 +38,7 @@ public class LongShiftRightModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongShiftRightModification equalModification = new LongShiftRightModification(shift);
         LongShiftRightModification differentModification = new LongShiftRightModification(10);
 
@@ -58,7 +58,7 @@ public class LongShiftRightModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongShiftRightModification equalModification = new LongShiftRightModification(shift);
 
         // Equal objects should have equal hash codes
@@ -66,25 +66,25 @@ public class LongShiftRightModificationTest {
     }
 
     @Test
-    public void testGetShift() {
+    void testGetShift() {
         assertEquals(shift, modification.getShift());
     }
 
     @Test
-    public void testSetShift() {
+    void testSetShift() {
         int newShift = 20;
         modification.setShift(newShift);
         assertEquals(newShift, modification.getShift());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongShiftRightModification{shift=3}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongShiftRightModification constructor = new LongShiftRightModification(5);
         assertNotNull(constructor);
         assertEquals(5, constructor.getShift());
@@ -95,7 +95,7 @@ public class LongShiftRightModificationTest {
     }
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongSubtractModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongSubtractModificationTest.java
@@ -20,18 +20,18 @@ import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongSubtractModificationTest {
+class LongSubtractModificationTest {
 
     private LongSubtractModification modification;
     private final Long subtrahend = 5L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongSubtractModification(subtrahend);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongSubtractModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -39,7 +39,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongSubtractModification equalModification = new LongSubtractModification(subtrahend);
         LongSubtractModification differentModification = new LongSubtractModification(10L);
 
@@ -59,7 +59,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsWithDifferentTypes() {
+    void testEqualsWithDifferentTypes() {
         // Test equality with different modification types that have same numeric value
         LongAddModification addMod = new LongAddModification(subtrahend);
 
@@ -69,7 +69,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsTransitivity() {
+    void testEqualsTransitivity() {
         // Test transitivity property of equals
         LongSubtractModification mod1 = new LongSubtractModification(subtrahend);
         LongSubtractModification mod2 = new LongSubtractModification(subtrahend);
@@ -82,7 +82,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsAfterModification() {
+    void testEqualsAfterModification() {
         // Create equal modifications
         LongSubtractModification mod1 = new LongSubtractModification(subtrahend);
         LongSubtractModification mod2 = new LongSubtractModification(subtrahend);
@@ -104,7 +104,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsWithBoundaryValues() {
+    void testEqualsWithBoundaryValues() {
         // Test with boundary values
         LongSubtractModification minMod = new LongSubtractModification(Long.MIN_VALUE);
         LongSubtractModification maxMod = new LongSubtractModification(Long.MAX_VALUE);
@@ -120,7 +120,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsCopyConstructor() {
+    void testEqualsCopyConstructor() {
         // Test equals with copy constructor
         LongSubtractModification original = new LongSubtractModification(42L);
         LongSubtractModification copy = new LongSubtractModification(original);
@@ -136,7 +136,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testEqualsWithNull() {
+    void testEqualsWithNull() {
         // Explicitly test the null case in equals
         LongSubtractModification mod = new LongSubtractModification(42L);
 
@@ -149,7 +149,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongSubtractModification equalModification = new LongSubtractModification(subtrahend);
 
         // Equal objects should have equal hash codes
@@ -157,7 +157,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testHashCodeConsistency() {
+    void testHashCodeConsistency() {
         // Test consistency: hashCode should return same value when called multiple
         // times
         int firstHashCode = modification.hashCode();
@@ -171,7 +171,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testHashCodeWithDifferentValues() {
+    void testHashCodeWithDifferentValues() {
         // Different values should have different hash codes (not guaranteed but
         // expected in this
         // case)
@@ -182,7 +182,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testHashCodeAfterModification() {
+    void testHashCodeAfterModification() {
         // Hash code should change when the object state changes
         LongSubtractModification mutableMod = new LongSubtractModification(subtrahend);
         int initialHash = mutableMod.hashCode();
@@ -196,25 +196,25 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testGetSubtrahend() {
+    void testGetSubtrahend() {
         assertEquals(subtrahend, modification.getSubtrahend());
     }
 
     @Test
-    public void testSetSubtrahend() {
+    void testSetSubtrahend() {
         Long newSubtrahend = 20L;
         modification.setSubtrahend(newSubtrahend);
         assertEquals(newSubtrahend, modification.getSubtrahend());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongSubtractModification{subtrahend=5}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongSubtractModification constructor = new LongSubtractModification(5L);
         assertNotNull(constructor);
         assertEquals(5, constructor.getSubtrahend());
@@ -225,7 +225,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);
@@ -238,7 +238,7 @@ public class LongSubtractModificationTest {
     }
 
     @Test
-    public void testGetValueWithNullInput() {
+    void testGetValueWithNullInput() {
         // Test direct call to modify with null input
         Long result = modification.modify(null);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongSwapEndianModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongSwapEndianModificationTest.java
@@ -18,17 +18,17 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongSwapEndianModificationTest {
+class LongSwapEndianModificationTest {
 
     private LongSwapEndianModification modification;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongSwapEndianModification();
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongSwapEndianModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -36,7 +36,7 @@ public class LongSwapEndianModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongSwapEndianModification equalModification = new LongSwapEndianModification();
 
         // Test reflexivity
@@ -52,7 +52,7 @@ public class LongSwapEndianModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongSwapEndianModification equalModification = new LongSwapEndianModification();
 
         // Equal objects should have equal hash codes
@@ -60,13 +60,13 @@ public class LongSwapEndianModificationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongSwapEndianModification{}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         // Test default constructor
         LongSwapEndianModification defaultConstructor = new LongSwapEndianModification();
         assertNotNull(defaultConstructor);
@@ -77,7 +77,7 @@ public class LongSwapEndianModificationTest {
     }
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/LongXorModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/LongXorModificationTest.java
@@ -18,18 +18,18 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongXorModificationTest {
+class LongXorModificationTest {
 
     private LongXorModification modification;
     private final Long xor = 5L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modification = new LongXorModification(xor);
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         LongXorModification copy = modification.createCopy();
         assertNotNull(copy);
         assertEquals(modification, copy);
@@ -38,7 +38,7 @@ public class LongXorModificationTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         LongXorModification equalModification = new LongXorModification(xor);
         LongXorModification differentModification = new LongXorModification(10L);
 
@@ -58,7 +58,7 @@ public class LongXorModificationTest {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LongXorModification equalModification = new LongXorModification(xor);
 
         // Equal objects should have equal hash codes
@@ -66,25 +66,25 @@ public class LongXorModificationTest {
     }
 
     @Test
-    public void testGetXor() {
+    void testGetXor() {
         assertEquals(xor, modification.getXor());
     }
 
     @Test
-    public void testSetXor() {
+    void testSetXor() {
         Long newXor = 20L;
         modification.setXor(newXor);
         assertEquals(newXor, modification.getXor());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "LongXorModification{xor=5}";
         assertEquals(expected, modification.toString());
     }
 
     @Test
-    public void testConstructors() {
+    void testConstructors() {
         LongXorModification constuctor = new LongXorModification(2L);
         assertNotNull(constuctor);
         assertEquals(2L, constuctor.getXor());
@@ -98,7 +98,7 @@ public class LongXorModificationTest {
     // but we can indirectly test its behavior through public methods
 
     @Test
-    public void testModifyWithNull() {
+    void testModifyWithNull() {
         // Create a ModifiableLong with null value
         ModifiableLong modifiable = new ModifiableLong();
         modifiable.setOriginalValue(null);

--- a/src/test/java/de/rub/nds/modifiablevariable/mlong/ModifiableLongTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/mlong/ModifiableLongTest.java
@@ -21,13 +21,13 @@ import de.rub.nds.modifiablevariable.longint.ModifiableLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableLongTest {
+class ModifiableLongTest {
 
     private ModifiableLong long1;
     private ModifiableLong long2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         long1 = new ModifiableLong();
         long1.setOriginalValue(2L);
         long2 = new ModifiableLong();
@@ -36,7 +36,7 @@ public class ModifiableLongTest {
 
     /** Test of getAssertEquals method, of class ModifiableLong. */
     @Test
-    public void testGetAssertEquals() {
+    void testGetAssertEquals() {
         assertNull(long1.getAssertEquals());
         long1.setAssertEquals(42L);
         assertEquals(Long.valueOf(42L), long1.getAssertEquals());
@@ -44,7 +44,7 @@ public class ModifiableLongTest {
 
     /** Test of setAssertEquals method, of class ModifiableLong. */
     @Test
-    public void testSetAssertEquals() {
+    void testSetAssertEquals() {
         long1.setAssertEquals(42L);
         assertEquals(Long.valueOf(42L), long1.getAssertEquals());
 
@@ -54,7 +54,7 @@ public class ModifiableLongTest {
 
     /** Test of isOriginalValueModified method, of class ModifiableLong. */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         // Initial state - not modified
         assertFalse(long1.isOriginalValueModified());
 
@@ -69,7 +69,7 @@ public class ModifiableLongTest {
 
     /** Test of getByteArray method, of class ModifiableLong. */
     @Test
-    public void testGetByteArray() {
+    void testGetByteArray() {
         // Test 8-byte representation
         byte[] expected8 = new byte[] {0, 0, 0, 0, 0, 0, 0, 2};
         assertArrayEquals(expected8, long1.getByteArray(8));
@@ -86,7 +86,7 @@ public class ModifiableLongTest {
 
     /** Test of validateAssertions method, of class ModifiableLong. */
     @Test
-    public void testValidateAssertions() {
+    void testValidateAssertions() {
         // No assertions set
         assertTrue(long1.validateAssertions());
 
@@ -106,7 +106,7 @@ public class ModifiableLongTest {
 
     /** Test of getOriginalValue method, of class ModifiableLong. */
     @Test
-    public void testGetOriginalValue() {
+    void testGetOriginalValue() {
         assertEquals(2L, long1.getOriginalValue());
 
         ModifiableLong nullLong = new ModifiableLong();
@@ -115,7 +115,7 @@ public class ModifiableLongTest {
 
     /** Test of setOriginalValue method, of class ModifiableLong. */
     @Test
-    public void testSetOriginalValue() {
+    void testSetOriginalValue() {
         long1.setOriginalValue(42L);
         assertEquals(42L, long1.getOriginalValue());
 
@@ -125,7 +125,7 @@ public class ModifiableLongTest {
 
     /** Test of toString method, of class ModifiableLong. */
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "ModifiableLong{originalValue=2}";
         assertEquals(expected, long1.toString());
 
@@ -144,7 +144,7 @@ public class ModifiableLongTest {
 
     /** Test of equals method, of class ModifiableLong. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         assertEquals(long1, long2);
 
         // Different original value but same computed value
@@ -196,7 +196,7 @@ public class ModifiableLongTest {
 
     /** Test of hashCode method, of class ModifiableLong. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         assertEquals(long1.hashCode(), long2.hashCode());
 
         // Same computed value, different original
@@ -221,7 +221,7 @@ public class ModifiableLongTest {
     }
 
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         ModifiableLong copy = long1.createCopy();
         assertEquals(long1, copy);
         assertEquals(long1.getOriginalValue(), copy.getOriginalValue());
@@ -233,7 +233,7 @@ public class ModifiableLongTest {
     }
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         ModifiableLong defaultConstructor = new ModifiableLong();
         assertNull(defaultConstructor.getOriginalValue());
 

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/BigIntegerSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/BigIntegerSerializationTest.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BigIntegerSerializationTest {
+class BigIntegerSerializationTest {
 
     private static final Logger LOGGER = LogManager.getLogger(BigIntegerSerializationTest.class);
 
@@ -43,7 +43,7 @@ public class BigIntegerSerializationTest {
     private Unmarshaller um;
 
     @BeforeEach
-    public void setUp() throws JAXBException {
+    void setUp() throws JAXBException {
         start = new ModifiableBigInteger();
         start.setOriginalValue(BigInteger.TEN);
         expectedResult = null;
@@ -61,7 +61,7 @@ public class BigIntegerSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeSimple() throws Exception {
+    void testSerializeDeserializeSimple() throws Exception {
         start.clearModifications();
         m.marshal(start, writer);
 
@@ -78,7 +78,7 @@ public class BigIntegerSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithModification() throws Exception {
+    void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<BigInteger> modifier = new BigIntegerAddModification(BigInteger.ONE);
         start.setModifications(modifier);
         m.marshal(start, writer);

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteArraySerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteArraySerializationTest.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteArraySerializationTest {
+class ByteArraySerializationTest {
 
     private static final Logger LOGGER = LogManager.getLogger(ByteArraySerializationTest.class);
 
@@ -40,7 +40,7 @@ public class ByteArraySerializationTest {
     private Unmarshaller um;
 
     @BeforeEach
-    public void setUp() throws JAXBException {
+    void setUp() throws JAXBException {
         start = new ModifiableByteArray();
         start.setOriginalValue(new byte[] {(byte) 0xff, 1, 2, 3});
         expectedResult = null;
@@ -60,7 +60,7 @@ public class ByteArraySerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeSimple() throws Exception {
+    void testSerializeDeserializeSimple() throws Exception {
         start.clearModifications();
         start.setAssertEquals(new byte[] {(byte) 0xff, 5, 44, 3});
         m.marshal(start, writer);
@@ -78,7 +78,7 @@ public class ByteArraySerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithModification() throws Exception {
+    void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<byte[]> modifier =
                 new ByteArrayInsertValueModification(new byte[] {1, 2}, 0);
         start.setModifications(modifier);

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/ByteSerializationTest.java
@@ -19,7 +19,7 @@ import java.io.StringWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteSerializationTest {
+class ByteSerializationTest {
 
     private ModifiableByte start;
     private Byte expectedResult, result;
@@ -29,7 +29,7 @@ public class ByteSerializationTest {
     private Unmarshaller um;
 
     @BeforeEach
-    public void setUp() throws JAXBException {
+    void setUp() throws JAXBException {
         start = new ModifiableByte();
         start.setOriginalValue((byte) 10);
 
@@ -47,7 +47,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeSimple() throws Exception {
+    void testSerializeDeserializeSimple() throws Exception {
         start.clearModifications();
         m.marshal(start, writer);
 
@@ -63,7 +63,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithAddModification() throws Exception {
+    void testSerializeDeserializeWithAddModification() throws Exception {
         ByteAddModification mod = new ByteAddModification((byte) 5);
         start.setModifications(mod);
 
@@ -80,7 +80,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithSubtractModification() throws Exception {
+    void testSerializeDeserializeWithSubtractModification() throws Exception {
         ByteSubtractModification mod = new ByteSubtractModification((byte) 3);
         start.setModifications(mod);
 
@@ -97,7 +97,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithXorModification() throws Exception {
+    void testSerializeDeserializeWithXorModification() throws Exception {
         ByteXorModification mod = new ByteXorModification((byte) 6);
         start.setModifications(mod);
 
@@ -114,7 +114,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithExplicitValueModification() throws Exception {
+    void testSerializeDeserializeWithExplicitValueModification() throws Exception {
         ByteExplicitValueModification mod = new ByteExplicitValueModification((byte) 42);
         start.setModifications(mod);
 
@@ -131,7 +131,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithDoubleModification() throws Exception {
+    void testSerializeDeserializeWithDoubleModification() throws Exception {
         // Create a chain of modifications: add 5, then XOR with 3
         ByteAddModification addMod = new ByteAddModification((byte) 5);
         ByteXorModification xorMod = new ByteXorModification((byte) 3);
@@ -156,7 +156,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithNullValue() throws Exception {
+    void testSerializeDeserializeWithNullValue() throws Exception {
         ModifiableByte nullByte = new ModifiableByte();
 
         m.marshal(nullByte, writer);
@@ -169,7 +169,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithAssertions() throws Exception {
+    void testSerializeDeserializeWithAssertions() throws Exception {
         start.setAssertEquals((byte) 15);
         start.setModifications(new ByteAddModification((byte) 5));
 
@@ -184,7 +184,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithMinMaxValues() throws Exception {
+    void testSerializeDeserializeWithMinMaxValues() throws Exception {
         // Test with MIN_VALUE
         start.setOriginalValue(Byte.MIN_VALUE);
 
@@ -210,7 +210,7 @@ public class ByteSerializationTest {
     }
 
     @Test
-    public void testCopyConstructorSerializationConsistency() throws Exception {
+    void testCopyConstructorSerializationConsistency() throws Exception {
         // Set up original with modifications
         start.setModifications(new ByteAddModification((byte) 5));
         start.setAssertEquals((byte) 15);

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/LongSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/LongSerializationTest.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LongSerializationTest {
+class LongSerializationTest {
 
     private static final Logger LOGGER = LogManager.getLogger(LongSerializationTest.class);
 
@@ -41,7 +41,7 @@ public class LongSerializationTest {
     private Unmarshaller um;
 
     @BeforeEach
-    public void setUp() throws JAXBException {
+    void setUp() throws JAXBException {
         start = new ModifiableLong();
         start.setOriginalValue(10L);
         expectedResult = null;
@@ -59,7 +59,7 @@ public class LongSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeSimple() throws Exception {
+    void testSerializeDeserializeSimple() throws Exception {
         start.clearModifications();
         m.marshal(start, writer);
 
@@ -75,7 +75,7 @@ public class LongSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithModification() throws Exception {
+    void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<Long> modifier = new LongAddModification(1L);
         start.setModifications(modifier);
         m.marshal(start, writer);

--- a/src/test/java/de/rub/nds/modifiablevariable/serialization/StringSerializationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/serialization/StringSerializationTest.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringSerializationTest {
+class StringSerializationTest {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -40,7 +40,7 @@ public class StringSerializationTest {
     private Unmarshaller um;
 
     @BeforeEach
-    public void setUp() throws JAXBException {
+    void setUp() throws JAXBException {
         start = new ModifiableString("Hello from Test ❤️\\ \u0000 \u0001 \u0006");
         expectedResult = null;
         result = null;
@@ -55,7 +55,7 @@ public class StringSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeSimple() throws Exception {
+    void testSerializeDeserializeSimple() throws Exception {
         start.clearModifications();
         start.setAssertEquals("Hello from Test 2 \\ \u0000 \u0001 \u0006");
         m.marshal(start, writer);
@@ -73,7 +73,7 @@ public class StringSerializationTest {
     }
 
     @Test
-    public void testSerializeDeserializeWithModification() throws Exception {
+    void testSerializeDeserializeWithModification() throws Exception {
         VariableModification<String> modifier = new StringInsertValueModification("Uff! ", 0);
         start.setModifications(modifier);
         m.marshal(start, writer);

--- a/src/test/java/de/rub/nds/modifiablevariable/singlebyte/ByteModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/singlebyte/ByteModificationTest.java
@@ -13,13 +13,13 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ByteModificationTest {
+class ByteModificationTest {
 
     private ModifiableByte start;
     private Byte expectedResult, result;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         start = new ModifiableByte();
         start.setOriginalValue(Byte.valueOf("10"));
         expectedResult = null;
@@ -28,7 +28,7 @@ public class ByteModificationTest {
 
     /** Test of add method, of class ByteAddModification. */
     @Test
-    public void testAdd() {
+    void testAdd() {
         VariableModification<Byte> modifier = new ByteAddModification(Byte.valueOf("1"));
         start.setModifications(modifier);
         expectedResult = Byte.valueOf("11");
@@ -39,7 +39,7 @@ public class ByteModificationTest {
 
     /** Test edge cases for ByteAddModification */
     @Test
-    public void testAddEdgeCases() {
+    void testAddEdgeCases() {
         // Test overflow: 127 + 1 = -128 (byte overflow)
         ModifiableByte maxByte = new ModifiableByte(Byte.MAX_VALUE);
         ByteAddModification overflowModifier = new ByteAddModification((byte) 1);
@@ -93,7 +93,7 @@ public class ByteModificationTest {
 
     /** Test of sub method, of class ByteSubtractModification. */
     @Test
-    public void testSub() {
+    void testSub() {
         VariableModification<Byte> modifier = new ByteSubtractModification(Byte.valueOf("1"));
         start.setModifications(modifier);
         expectedResult = Byte.valueOf("9");
@@ -104,7 +104,7 @@ public class ByteModificationTest {
 
     /** Test edge cases for ByteSubtractModification */
     @Test
-    public void testSubEdgeCases() {
+    void testSubEdgeCases() {
         // Test underflow: -128 - 1 = 127 (byte underflow)
         ModifiableByte minByte = new ModifiableByte(Byte.MIN_VALUE);
         ByteSubtractModification underflowModifier = new ByteSubtractModification((byte) 1);
@@ -159,7 +159,7 @@ public class ByteModificationTest {
 
     /** Test of xor method, of class ByteXorModification. */
     @Test
-    public void testXor() {
+    void testXor() {
         VariableModification<Byte> modifier = new ByteXorModification(Byte.valueOf("2"));
         start.setModifications(modifier);
         expectedResult = Byte.valueOf("8");
@@ -170,7 +170,7 @@ public class ByteModificationTest {
 
     /** Test edge cases for ByteXorModification */
     @Test
-    public void testXorEdgeCases() {
+    void testXorEdgeCases() {
 
         // Test XOR with same value (should be 0)
         ByteXorModification sameModifier = new ByteXorModification((byte) 10);
@@ -220,7 +220,7 @@ public class ByteModificationTest {
 
     /** Test of explicitValue method, of class ByteExplicitValueModification. */
     @Test
-    public void testExplicitValue() {
+    void testExplicitValue() {
         VariableModification<Byte> modifier = new ByteExplicitValueModification(Byte.valueOf("7"));
         start.setModifications(modifier);
         expectedResult = Byte.valueOf("7");
@@ -231,7 +231,7 @@ public class ByteModificationTest {
 
     /** Test edge cases for ByteExplicitValueModification */
     @Test
-    public void testExplicitValueEdgeCases() {
+    void testExplicitValueEdgeCases() {
         // Test with extreme values
         ByteExplicitValueModification maxModifier =
                 new ByteExplicitValueModification(Byte.MAX_VALUE);
@@ -297,7 +297,7 @@ public class ByteModificationTest {
 
     /** Test chaining multiple modifications together */
     @Test
-    public void testModificationChaining() {
+    void testModificationChaining() {
         // Chain add and XOR
         ByteAddModification addMod = new ByteAddModification((byte) 2);
         ByteXorModification xorMod = new ByteXorModification((byte) 3);
@@ -323,7 +323,7 @@ public class ByteModificationTest {
 
     /** Test CreateCopy methods for all modification types */
     @Test
-    public void testCreateCopyForModifications() {
+    void testCreateCopyForModifications() {
         // Test ByteAddModification
         ByteAddModification addMod = new ByteAddModification((byte) 5);
         VariableModification<Byte> addCopy = addMod.createCopy();

--- a/src/test/java/de/rub/nds/modifiablevariable/singlebyte/ModifiableByteTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/singlebyte/ModifiableByteTest.java
@@ -12,13 +12,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableByteTest {
+class ModifiableByteTest {
 
     private ModifiableByte byte1;
     private ModifiableByte byte2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         byte1 = new ModifiableByte();
         byte1.setOriginalValue((byte) 3);
         byte2 = new ModifiableByte();
@@ -27,7 +27,7 @@ public class ModifiableByteTest {
 
     /** Test of getAssertEquals method, of class ModifiableByte. */
     @Test
-    public void testGetAssertEquals() {
+    void testGetAssertEquals() {
         assertNull(byte1.getAssertEquals());
 
         Byte expected = (byte) 5;
@@ -37,7 +37,7 @@ public class ModifiableByteTest {
 
     /** Test of setAssertEquals method, of class ModifiableByte. */
     @Test
-    public void testSetAssertEquals() {
+    void testSetAssertEquals() {
         Byte expected = (byte) 42;
         byte1.setAssertEquals(expected);
         assertEquals(expected, byte1.getAssertEquals());
@@ -49,7 +49,7 @@ public class ModifiableByteTest {
 
     /** Test of isOriginalValueModified method, of class ModifiableByte. */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         // Initially not modified
         assertFalse(byte1.isOriginalValueModified());
 
@@ -71,7 +71,7 @@ public class ModifiableByteTest {
 
     /** Test of validateAssertions method, of class ModifiableByte. */
     @Test
-    public void testValidateAssertions() {
+    void testValidateAssertions() {
         // No assertion set
         assertTrue(byte1.validateAssertions());
 
@@ -90,7 +90,7 @@ public class ModifiableByteTest {
 
     /** Test of getOriginalValue method, of class ModifiableByte. */
     @Test
-    public void testGetOriginalValue() {
+    void testGetOriginalValue() {
         assertEquals((byte) 3, byte1.getOriginalValue());
 
         ModifiableByte emptyByte = new ModifiableByte();
@@ -102,7 +102,7 @@ public class ModifiableByteTest {
 
     /** Test of setOriginalValue method, of class ModifiableByte. */
     @Test
-    public void testSetOriginalValue() {
+    void testSetOriginalValue() {
         byte1.setOriginalValue((byte) 77);
         assertEquals((byte) 77, byte1.getOriginalValue());
 
@@ -113,7 +113,7 @@ public class ModifiableByteTest {
 
     /** Test of toString method, of class ModifiableByte. */
     @Test
-    public void testToString() {
+    void testToString() {
         String result = byte1.toString();
         assertTrue(result.contains("originalValue=3"));
 
@@ -126,7 +126,7 @@ public class ModifiableByteTest {
 
     /** Test of equals method, of class ModifiableByte. */
     @Test
-    public void testEquals() {
+    void testEquals() {
         // Initial test from original code
         assertEquals(byte1, byte2);
         byte2.setOriginalValue((byte) 4);
@@ -183,7 +183,7 @@ public class ModifiableByteTest {
 
     /** Test of hashCode method, of class ModifiableByte. */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Equal objects should have equal hash codes
         assertEquals(byte1.hashCode(), byte2.hashCode());
 
@@ -203,7 +203,7 @@ public class ModifiableByteTest {
 
     /** Test of copy constructor and createCopy method. */
     @Test
-    public void testCopyMethods() {
+    void testCopyMethods() {
         // Set up a ModifiableByte with modifications and assertion
         byte1.setModifications(new ByteAddModification((byte) 2));
         byte1.setAssertEquals((byte) 5);

--- a/src/test/java/de/rub/nds/modifiablevariable/string/ModifiableStringTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/ModifiableStringTest.java
@@ -22,20 +22,20 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableStringTest {
+class ModifiableStringTest {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private ModifiableString string;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         string = new ModifiableString();
         string.setOriginalValue("TestString");
     }
 
     /** Test default constructor */
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         ModifiableString defaultString = new ModifiableString();
         assertNull(defaultString.getOriginalValue());
         assertNull(defaultString.getValue());
@@ -43,7 +43,7 @@ public class ModifiableStringTest {
 
     /** Test constructor with original value */
     @Test
-    public void testConstructorWithValue() {
+    void testConstructorWithValue() {
         ModifiableString valueString = new ModifiableString("InitialValue");
         assertEquals("InitialValue", valueString.getOriginalValue());
         assertEquals("InitialValue", valueString.getValue());
@@ -51,7 +51,7 @@ public class ModifiableStringTest {
 
     /** Test copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         // Set up a string with modifications
         string.setModifications(new StringAppendValueModification("_Appended"));
         string.setAssertEquals("TestString_Appended");
@@ -68,7 +68,7 @@ public class ModifiableStringTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopy() {
+    void testCreateCopy() {
         // Set up a string with modifications
         string.setModifications(new StringPrependValueModification("Prepended_"));
         string.setAssertEquals("Prepended_TestString");
@@ -85,7 +85,7 @@ public class ModifiableStringTest {
 
     /** Test isOriginalValueModified method */
     @Test
-    public void testIsOriginalValueModified() {
+    void testIsOriginalValueModified() {
         // Without modifications
         assertFalse(string.isOriginalValueModified());
 
@@ -106,7 +106,7 @@ public class ModifiableStringTest {
 
     /** Test getter and setter methods */
     @Test
-    public void testGetterAndSetterMethods() {
+    void testGetterAndSetterMethods() {
         assertEquals("TestString", string.getOriginalValue());
         assertEquals("TestString", string.getValue());
 
@@ -122,7 +122,7 @@ public class ModifiableStringTest {
 
     /** Test assertion methods */
     @Test
-    public void testAssertions() {
+    void testAssertions() {
         // When assertion equals original value
         string.setAssertEquals("TestString");
         assertTrue(string.validateAssertions());
@@ -138,7 +138,7 @@ public class ModifiableStringTest {
 
     /** Test assertions with null values */
     @Test
-    public void testAssertionsWithNull() {
+    void testAssertionsWithNull() {
         // When original value is null and no assertion is set
         ModifiableString nullString = new ModifiableString();
         assertTrue(nullString.validateAssertions());
@@ -146,7 +146,7 @@ public class ModifiableStringTest {
 
     /** Test getByteArray method */
     @Test
-    public void testGetByteArray() {
+    void testGetByteArray() {
         // Test with regular string
         byte[] expected = "TestString".getBytes(StandardCharsets.ISO_8859_1);
         byte[] actual = string.getByteArray();
@@ -161,21 +161,21 @@ public class ModifiableStringTest {
 
     /** Test getByteArray with null value */
     @Test
-    public void testGetByteArrayWithNull() {
+    void testGetByteArrayWithNull() {
         ModifiableString nullString = new ModifiableString();
         assertThrows(NullPointerException.class, () -> nullString.getByteArray());
     }
 
     /** Test equals method with same object */
     @Test
-    public void testEqualsSameObject() {
+    void testEqualsSameObject() {
         // Same object reference should be equal
         assertTrue(string.equals(string));
     }
 
     /** Test equals method with same values */
     @Test
-    public void testEqualsSameValues() {
+    void testEqualsSameValues() {
         // Equal objects with same original value
         ModifiableString string2 = new ModifiableString();
         string2.setOriginalValue("TestString");
@@ -185,7 +185,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with modifications */
     @Test
-    public void testEqualsWithModifications() {
+    void testEqualsWithModifications() {
         // Equal objects with same modifications
         ModifiableString string2 = new ModifiableString();
         string2.setOriginalValue("TestString");
@@ -207,7 +207,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with different string values */
     @Test
-    public void testEqualsWithDifferentValues() {
+    void testEqualsWithDifferentValues() {
         // Different objects with different modifications
         ModifiableString string2 = new ModifiableString();
         string2.setOriginalValue("TestString");
@@ -218,7 +218,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with different types of modification */
     @Test
-    public void testEqualsWithDifferentModificationTypes() {
+    void testEqualsWithDifferentModificationTypes() {
         // Objects with different types of modifications but same final value
         ModifiableString string1 = new ModifiableString();
         string1.setOriginalValue("Test");
@@ -234,7 +234,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with null values */
     @Test
-    public void testEqualsWithNullValues() {
+    void testEqualsWithNullValues() {
         // Equal objects with null values
         ModifiableString nullString1 = new ModifiableString();
         ModifiableString nullString2 = new ModifiableString();
@@ -249,7 +249,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with null and different types */
     @Test
-    public void testEqualsWithNullAndDifferentTypes() {
+    void testEqualsWithNullAndDifferentTypes() {
         // Inequality with null and different types
         assertFalse(string.equals(null));
         assertFalse(string.equals("TestString"));
@@ -259,7 +259,7 @@ public class ModifiableStringTest {
 
     /** Test equals method with explicit values */
     @Test
-    public void testEqualsWithExplicitValues() {
+    void testEqualsWithExplicitValues() {
         // Two objects with different original values but same explicit value
         ModifiableString string1 = new ModifiableString("Original1");
         ModifiableString string2 = new ModifiableString("Original2");
@@ -272,7 +272,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with basic values */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Equal objects should have same hash code
         ModifiableString string2 = new ModifiableString();
         string2.setOriginalValue("TestString");
@@ -281,7 +281,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with modifications */
     @Test
-    public void testHashCodeWithModifications() {
+    void testHashCodeWithModifications() {
         // Objects with same modified value should have same hash code
         ModifiableString string1 = new ModifiableString();
         string1.setOriginalValue("TestString");
@@ -296,7 +296,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with different values */
     @Test
-    public void testHashCodeWithDifferentValues() {
+    void testHashCodeWithDifferentValues() {
         // Objects with different modified values should have different hash codes
         ModifiableString string1 = new ModifiableString();
         string1.setOriginalValue("TestString");
@@ -309,7 +309,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with same result from different original values */
     @Test
-    public void testHashCodeWithSameResult() {
+    void testHashCodeWithSameResult() {
         // Different original values but same final value should have same hash code
         ModifiableString string1 = new ModifiableString();
         string1.setOriginalValue("Test");
@@ -325,7 +325,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with explicit values */
     @Test
-    public void testHashCodeWithExplicitValues() {
+    void testHashCodeWithExplicitValues() {
         // Different original values but same explicit value should have same hash code
         ModifiableString string1 = new ModifiableString("Original1");
         ModifiableString string2 = new ModifiableString("Original2");
@@ -339,7 +339,7 @@ public class ModifiableStringTest {
 
     /** Test hashCode method with null value */
     @Test
-    public void testHashCodeWithNull() {
+    void testHashCodeWithNull() {
         // Null value handling
         ModifiableString nullString = new ModifiableString();
         int hashCode = nullString.hashCode();
@@ -355,7 +355,7 @@ public class ModifiableStringTest {
 
     /** Test toString method */
     @Test
-    public void testToString() {
+    void testToString() {
         String expectedToString = "ModifiableString{originalValue='TestString'}";
         assertEquals(expectedToString, string.toString());
 
@@ -377,7 +377,7 @@ public class ModifiableStringTest {
 
     /** Test with complex modification chains */
     @Test
-    public void testComplexModifications() {
+    void testComplexModifications() {
         // Create a chain of modifications
         StringAppendValueModification append = new StringAppendValueModification("_Append");
         StringPrependValueModification prepend = new StringPrependValueModification("Prepend_");
@@ -391,7 +391,7 @@ public class ModifiableStringTest {
 
     /** Test modification reset */
     @Test
-    public void testModificationReset() {
+    void testModificationReset() {
         string.setModifications(new StringAppendValueModification("_Appended"));
         assertEquals("TestString_Appended", string.getValue());
 

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringAppendValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringAppendValueModificationTest.java
@@ -12,21 +12,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringAppendValueModificationTest {
+class StringAppendValueModificationTest {
 
     private ModifiableString modifiableString;
     private final String originalString = "testString";
     private final String appendValue = "APPEND";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalString);
     }
 
     /** Test basic append functionality */
     @Test
-    public void testBasicAppend() {
+    void testBasicAppend() {
         StringAppendValueModification modifier = new StringAppendValueModification(appendValue);
         modifiableString.setModifications(modifier);
         assertEquals(originalString + appendValue, modifiableString.getValue());
@@ -35,7 +35,7 @@ public class StringAppendValueModificationTest {
 
     /** Test append with empty string */
     @Test
-    public void testAppendEmptyString() {
+    void testAppendEmptyString() {
         StringAppendValueModification modifier = new StringAppendValueModification("");
         modifiableString.setModifications(modifier);
         assertEquals(originalString, modifiableString.getValue());
@@ -43,7 +43,7 @@ public class StringAppendValueModificationTest {
 
     /** Test append to empty string */
     @Test
-    public void testAppendToEmptyString() {
+    void testAppendToEmptyString() {
         ModifiableString emptyString = new ModifiableString();
         emptyString.setOriginalValue("");
 
@@ -55,7 +55,7 @@ public class StringAppendValueModificationTest {
 
     /** Test append to null string */
     @Test
-    public void testAppendToNullString() {
+    void testAppendToNullString() {
         ModifiableString nullString = new ModifiableString();
         nullString.setOriginalValue(null);
 
@@ -67,7 +67,7 @@ public class StringAppendValueModificationTest {
 
     /** Test that null append value is not allowed */
     @Test
-    public void testNullAppendValue() {
+    void testNullAppendValue() {
         assertThrows(
                 NullPointerException.class,
                 () -> {
@@ -78,7 +78,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the getter and setter for appendValue */
     @Test
-    public void testAppendValueGetterAndSetter() {
+    void testAppendValueGetterAndSetter() {
         StringAppendValueModification modifier = new StringAppendValueModification("initial");
         assertEquals("initial", modifier.getAppendValue());
 
@@ -95,7 +95,7 @@ public class StringAppendValueModificationTest {
 
     /** Test append with special characters */
     @Test
-    public void testAppendWithSpecialCharacters() {
+    void testAppendWithSpecialCharacters() {
         String specialChars = "@#$%^&*()";
         StringAppendValueModification modifier = new StringAppendValueModification(specialChars);
         modifiableString.setModifications(modifier);
@@ -104,7 +104,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the equals method */
     @Test
-    public void testEqualsMethod() {
+    void testEqualsMethod() {
         StringAppendValueModification mod1 = new StringAppendValueModification("value");
         StringAppendValueModification mod2 = new StringAppendValueModification("value");
         StringAppendValueModification mod3 = new StringAppendValueModification("different");
@@ -125,7 +125,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the hashCode method */
     @Test
-    public void testHashCodeMethod() {
+    void testHashCodeMethod() {
         StringAppendValueModification mod1 = new StringAppendValueModification("value");
         StringAppendValueModification mod2 = new StringAppendValueModification("value");
 
@@ -139,7 +139,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the toString method */
     @Test
-    public void testToStringMethod() {
+    void testToStringMethod() {
         StringAppendValueModification modifier = new StringAppendValueModification("test");
         String toString = modifier.toString();
 
@@ -149,7 +149,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         StringAppendValueModification original = new StringAppendValueModification("original");
         StringAppendValueModification copy = new StringAppendValueModification(original);
 
@@ -164,7 +164,7 @@ public class StringAppendValueModificationTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopyMethod() {
+    void testCreateCopyMethod() {
         StringAppendValueModification original = new StringAppendValueModification("original");
         StringAppendValueModification copy = original.createCopy();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringDeleteModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringDeleteModificationTest.java
@@ -12,20 +12,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringDeleteModificationTest {
+class StringDeleteModificationTest {
 
     private ModifiableString modifiableString;
     private final String originalString = "testString";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalString);
     }
 
     /** Test the basic deletion from the start of the string */
     @Test
-    public void testBasicDeleteFromStart() {
+    void testBasicDeleteFromStart() {
         StringDeleteModification modifier = new StringDeleteModification(0, 4);
         modifiableString.setModifications(modifier);
         assertEquals("String", modifiableString.getValue());
@@ -34,7 +34,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion from the middle of the string */
     @Test
-    public void testDeleteFromMiddle() {
+    void testDeleteFromMiddle() {
         StringDeleteModification modifier = new StringDeleteModification(4, 2);
         modifiableString.setModifications(modifier);
         assertEquals("testring", modifiableString.getValue());
@@ -42,7 +42,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion from the end of the string */
     @Test
-    public void testDeleteFromEnd() {
+    void testDeleteFromEnd() {
         StringDeleteModification modifier = new StringDeleteModification(6, 4);
         modifiableString.setModifications(modifier);
         assertEquals("testSt", modifiableString.getValue());
@@ -50,7 +50,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion with count exceeding string length */
     @Test
-    public void testDeleteCountOverflow() {
+    void testDeleteCountOverflow() {
         StringDeleteModification modifier = new StringDeleteModification(2, 100);
         modifiableString.setModifications(modifier);
         assertEquals("te", modifiableString.getValue());
@@ -58,7 +58,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion with negative start position */
     @Test
-    public void testDeleteWithNegativeStart() {
+    void testDeleteWithNegativeStart() {
         StringDeleteModification modifier = new StringDeleteModification(-1, 1);
         modifiableString.setModifications(modifier);
         assertEquals("testStrin", modifiableString.getValue());
@@ -66,7 +66,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion with start position exceeding string length (wrap around using modulo) */
     @Test
-    public void testDeleteWithStartOverflow() {
+    void testDeleteWithStartOverflow() {
         StringDeleteModification modifier = new StringDeleteModification(20, 2);
         modifiableString.setModifications(modifier);
         // 20 % 10 = 0, so it should delete from position 0
@@ -75,7 +75,7 @@ public class StringDeleteModificationTest {
 
     /** Test with empty string input */
     @Test
-    public void testDeleteFromEmptyString() {
+    void testDeleteFromEmptyString() {
         ModifiableString emptyString = new ModifiableString();
         emptyString.setOriginalValue("");
 
@@ -88,7 +88,7 @@ public class StringDeleteModificationTest {
 
     /** Test with null input */
     @Test
-    public void testDeleteFromNullString() {
+    void testDeleteFromNullString() {
         ModifiableString nullString = new ModifiableString();
         nullString.setOriginalValue(null);
 
@@ -101,7 +101,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion with zero count */
     @Test
-    public void testDeleteZeroCount() {
+    void testDeleteZeroCount() {
         StringDeleteModification modifier = new StringDeleteModification(2, 0);
         modifiableString.setModifications(modifier);
         // No characters should be deleted
@@ -110,7 +110,7 @@ public class StringDeleteModificationTest {
 
     /** Test deletion with negative count (should be treated as zero) */
     @Test
-    public void testDeleteNegativeCount() {
+    void testDeleteNegativeCount() {
         StringDeleteModification modifier = new StringDeleteModification(2, -3);
         modifiableString.setModifications(modifier);
         // Negative count should be treated as zero
@@ -119,7 +119,7 @@ public class StringDeleteModificationTest {
 
     /** Test the getter and setter for count */
     @Test
-    public void testCountGetterAndSetter() {
+    void testCountGetterAndSetter() {
         StringDeleteModification modifier = new StringDeleteModification(0, 5);
         assertEquals(5, modifier.getCount());
 
@@ -129,7 +129,7 @@ public class StringDeleteModificationTest {
 
     /** Test the getter and setter for startPosition */
     @Test
-    public void testStartPositionGetterAndSetter() {
+    void testStartPositionGetterAndSetter() {
         StringDeleteModification modifier = new StringDeleteModification(3, 2);
         assertEquals(3, modifier.getStartPosition());
 
@@ -139,7 +139,7 @@ public class StringDeleteModificationTest {
 
     /** Test the equals method */
     @Test
-    public void testEqualsMethod() {
+    void testEqualsMethod() {
         StringDeleteModification mod1 = new StringDeleteModification(3, 4);
         StringDeleteModification mod2 = new StringDeleteModification(3, 4);
         StringDeleteModification mod3 = new StringDeleteModification(2, 4);
@@ -164,7 +164,7 @@ public class StringDeleteModificationTest {
 
     /** Test the hashCode method */
     @Test
-    public void testHashCodeMethod() {
+    void testHashCodeMethod() {
         StringDeleteModification mod1 = new StringDeleteModification(3, 4);
         StringDeleteModification mod2 = new StringDeleteModification(3, 4);
 
@@ -178,7 +178,7 @@ public class StringDeleteModificationTest {
 
     /** Test the toString method */
     @Test
-    public void testToStringMethod() {
+    void testToStringMethod() {
         StringDeleteModification modifier = new StringDeleteModification(2, 3);
         String toString = modifier.toString();
 
@@ -189,7 +189,7 @@ public class StringDeleteModificationTest {
 
     /** Test the copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         StringDeleteModification original = new StringDeleteModification(4, 6);
         StringDeleteModification copy = new StringDeleteModification(original);
 
@@ -205,7 +205,7 @@ public class StringDeleteModificationTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopyMethod() {
+    void testCreateCopyMethod() {
         StringDeleteModification original = new StringDeleteModification(3, 5);
         StringDeleteModification copy = original.createCopy();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringExplicitValueModificationTest.java
@@ -12,21 +12,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringExplicitValueModificationTest {
+class StringExplicitValueModificationTest {
 
     private ModifiableString modifiableString;
     private final String originalString = "testString";
     private final String explicitValue = "EXPLICIT";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalString);
     }
 
     /** Test basic explicit value modification */
     @Test
-    public void testBasicExplicitValue() {
+    void testBasicExplicitValue() {
         StringExplicitValueModification modifier =
                 new StringExplicitValueModification(explicitValue);
         modifiableString.setModifications(modifier);
@@ -36,7 +36,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test with empty explicit value */
     @Test
-    public void testEmptyExplicitValue() {
+    void testEmptyExplicitValue() {
         StringExplicitValueModification modifier = new StringExplicitValueModification("");
         modifiableString.setModifications(modifier);
         assertEquals("", modifiableString.getValue());
@@ -44,7 +44,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test with explicit value applied to empty string */
     @Test
-    public void testExplicitValueOnEmptyString() {
+    void testExplicitValueOnEmptyString() {
         ModifiableString emptyString = new ModifiableString();
         emptyString.setOriginalValue("");
 
@@ -57,7 +57,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test with explicit value applied to null string */
     @Test
-    public void testExplicitValueOnNullString() {
+    void testExplicitValueOnNullString() {
         ModifiableString nullString = new ModifiableString();
         nullString.setOriginalValue(null);
 
@@ -71,7 +71,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test that null explicit value is not allowed */
     @Test
-    public void testNullExplicitValue() {
+    void testNullExplicitValue() {
         assertThrows(
                 NullPointerException.class,
                 () -> {
@@ -82,7 +82,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the getter and setter for explicitValue */
     @Test
-    public void testExplicitValueGetterAndSetter() {
+    void testExplicitValueGetterAndSetter() {
         StringExplicitValueModification modifier = new StringExplicitValueModification("initial");
         assertEquals("initial", modifier.getExplicitValue());
 
@@ -99,7 +99,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test with special characters in explicit value */
     @Test
-    public void testExplicitValueWithSpecialCharacters() {
+    void testExplicitValueWithSpecialCharacters() {
         String specialChars = "@#$%^&*()";
         StringExplicitValueModification modifier =
                 new StringExplicitValueModification(specialChars);
@@ -109,7 +109,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the equals method */
     @Test
-    public void testEqualsMethod() {
+    void testEqualsMethod() {
         StringExplicitValueModification mod1 = new StringExplicitValueModification("value");
         StringExplicitValueModification mod2 = new StringExplicitValueModification("value");
         StringExplicitValueModification mod3 = new StringExplicitValueModification("different");
@@ -130,7 +130,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the hashCode method */
     @Test
-    public void testHashCodeMethod() {
+    void testHashCodeMethod() {
         StringExplicitValueModification mod1 = new StringExplicitValueModification("value");
         StringExplicitValueModification mod2 = new StringExplicitValueModification("value");
 
@@ -144,7 +144,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the toString method */
     @Test
-    public void testToStringMethod() {
+    void testToStringMethod() {
         StringExplicitValueModification modifier = new StringExplicitValueModification("test");
         String toString = modifier.toString();
 
@@ -154,7 +154,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         StringExplicitValueModification original = new StringExplicitValueModification("original");
         StringExplicitValueModification copy = new StringExplicitValueModification(original);
 
@@ -169,7 +169,7 @@ public class StringExplicitValueModificationTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopyMethod() {
+    void testCreateCopyMethod() {
         StringExplicitValueModification original = new StringExplicitValueModification("original");
         StringExplicitValueModification copy = original.createCopy();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringInsertValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringInsertValueModificationTest.java
@@ -12,21 +12,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringInsertValueModificationTest {
+class StringInsertValueModificationTest {
 
     private ModifiableString modifiableString;
     private final String originalString = "testString";
     private final String insertValue = "INSERT";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalString);
     }
 
     /** Test basic insertion at the beginning of the string */
     @Test
-    public void testInsertAtBeginning() {
+    void testInsertAtBeginning() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, 0);
         modifiableString.setModifications(modifier);
         assertEquals("INSERTtestString", modifiableString.getValue());
@@ -35,7 +35,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion in the middle of the string */
     @Test
-    public void testInsertInMiddle() {
+    void testInsertInMiddle() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, 4);
         modifiableString.setModifications(modifier);
         assertEquals("testINSERTString", modifiableString.getValue());
@@ -43,7 +43,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion at the end of the string */
     @Test
-    public void testInsertAtEnd() {
+    void testInsertAtEnd() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, 10);
         modifiableString.setModifications(modifier);
         assertEquals("testStringINSERT", modifiableString.getValue());
@@ -51,7 +51,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion with negative position (inserts from the end) */
     @Test
-    public void testInsertWithNegativePosition() {
+    void testInsertWithNegativePosition() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, -1);
         modifiableString.setModifications(modifier);
         // -1 means to insert before the last character
@@ -60,7 +60,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion with position exceeding string length (appends to the end) */
     @Test
-    public void testInsertWithPositionOverflow() {
+    void testInsertWithPositionOverflow() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, 22);
         modifiableString.setModifications(modifier);
         // Position beyond string length should append to the end
@@ -69,7 +69,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion with empty string as the original value */
     @Test
-    public void testInsertIntoEmptyString() {
+    void testInsertIntoEmptyString() {
         ModifiableString emptyString = new ModifiableString();
         emptyString.setOriginalValue("");
 
@@ -81,7 +81,7 @@ public class StringInsertValueModificationTest {
 
     /** Test insertion with empty string as the insert value */
     @Test
-    public void testInsertEmptyString() {
+    void testInsertEmptyString() {
         StringInsertValueModification modifier = new StringInsertValueModification("", 5);
         modifiableString.setModifications(modifier);
 
@@ -91,7 +91,7 @@ public class StringInsertValueModificationTest {
 
     /** Test with null input */
     @Test
-    public void testInsertIntoNullString() {
+    void testInsertIntoNullString() {
         ModifiableString nullString = new ModifiableString();
         nullString.setOriginalValue(null);
 
@@ -104,7 +104,7 @@ public class StringInsertValueModificationTest {
 
     /** Test that null insert value is not allowed */
     @Test
-    public void testNullInsertValue() {
+    void testNullInsertValue() {
         assertThrows(
                 NullPointerException.class,
                 () -> {
@@ -114,7 +114,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the getter and setter for insertValue */
     @Test
-    public void testInsertValueGetterAndSetter() {
+    void testInsertValueGetterAndSetter() {
         StringInsertValueModification modifier = new StringInsertValueModification("initial", 0);
         assertEquals("initial", modifier.getInsertValue());
 
@@ -131,7 +131,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the getter and setter for startPosition */
     @Test
-    public void testStartPositionGetterAndSetter() {
+    void testStartPositionGetterAndSetter() {
         StringInsertValueModification modifier = new StringInsertValueModification(insertValue, 3);
         assertEquals(3, modifier.getStartPosition());
 
@@ -141,7 +141,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the equals method */
     @Test
-    public void testEqualsMethod() {
+    void testEqualsMethod() {
         StringInsertValueModification mod1 = new StringInsertValueModification("value", 3);
         StringInsertValueModification mod2 = new StringInsertValueModification("value", 3);
         StringInsertValueModification mod3 = new StringInsertValueModification("value", 4);
@@ -166,7 +166,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the hashCode method */
     @Test
-    public void testHashCodeMethod() {
+    void testHashCodeMethod() {
         StringInsertValueModification mod1 = new StringInsertValueModification("value", 3);
         StringInsertValueModification mod2 = new StringInsertValueModification("value", 3);
 
@@ -180,7 +180,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the toString method */
     @Test
-    public void testToStringMethod() {
+    void testToStringMethod() {
         StringInsertValueModification modifier = new StringInsertValueModification("test", 2);
         String toString = modifier.toString();
 
@@ -191,7 +191,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         StringInsertValueModification original = new StringInsertValueModification("original", 4);
         StringInsertValueModification copy = new StringInsertValueModification(original);
 
@@ -207,7 +207,7 @@ public class StringInsertValueModificationTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopyMethod() {
+    void testCreateCopyMethod() {
         StringInsertValueModification original = new StringInsertValueModification("original", 3);
         StringInsertValueModification copy = original.createCopy();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringModificationTest.java
@@ -14,19 +14,19 @@ import de.rub.nds.modifiablevariable.VariableModification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringModificationTest {
+class StringModificationTest {
 
     private ModifiableString modifiableString;
     private String originalValue = "TestValue";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalValue);
     }
 
     @Test
-    public void testAppendModification() {
+    void testAppendModification() {
         String appendValue = "Appended";
         VariableModification<String> modifier = new StringAppendValueModification(appendValue);
         modifiableString.setModifications(modifier);
@@ -35,7 +35,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testPrependModification() {
+    void testPrependModification() {
         String prependValue = "Prepended";
         VariableModification<String> modifier = new StringPrependValueModification(prependValue);
         modifiableString.setModifications(modifier);
@@ -44,7 +44,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testExplicitValueModification() {
+    void testExplicitValueModification() {
         String explicitValue = "CompletelyDifferent";
         VariableModification<String> modifier = new StringExplicitValueModification(explicitValue);
         modifiableString.setModifications(modifier);
@@ -54,7 +54,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testAppendWithEmptyString() {
+    void testAppendWithEmptyString() {
         String appendValue = "";
         VariableModification<String> modifier = new StringAppendValueModification(appendValue);
         modifiableString.setModifications(modifier);
@@ -63,7 +63,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testPrependWithEmptyString() {
+    void testPrependWithEmptyString() {
         String prependValue = "";
         VariableModification<String> modifier = new StringPrependValueModification(prependValue);
         modifiableString.setModifications(modifier);
@@ -72,7 +72,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testAppendToEmptyString() {
+    void testAppendToEmptyString() {
         modifiableString.setOriginalValue("");
         String appendValue = "JustAppended";
         VariableModification<String> modifier = new StringAppendValueModification(appendValue);
@@ -82,7 +82,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testPrependToEmptyString() {
+    void testPrependToEmptyString() {
         modifiableString.setOriginalValue("");
         String prependValue = "JustPrepended";
         VariableModification<String> modifier = new StringPrependValueModification(prependValue);
@@ -92,7 +92,7 @@ public class StringModificationTest {
     }
 
     @Test
-    public void testModifierEquality() {
+    void testModifierEquality() {
         String appendValue = "SomeValue";
         StringAppendValueModification modifier1 = new StringAppendValueModification(appendValue);
         StringAppendValueModification modifier2 = new StringAppendValueModification(appendValue);

--- a/src/test/java/de/rub/nds/modifiablevariable/string/StringPrependValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/string/StringPrependValueModificationTest.java
@@ -12,21 +12,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StringPrependValueModificationTest {
+class StringPrependValueModificationTest {
 
     private ModifiableString modifiableString;
     private final String originalString = "testString";
     private final String prependValue = "PREPEND";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         modifiableString = new ModifiableString();
         modifiableString.setOriginalValue(originalString);
     }
 
     /** Test basic prepend functionality */
     @Test
-    public void testBasicPrepend() {
+    void testBasicPrepend() {
         StringPrependValueModification modifier = new StringPrependValueModification(prependValue);
         modifiableString.setModifications(modifier);
         assertEquals(prependValue + originalString, modifiableString.getValue());
@@ -35,7 +35,7 @@ public class StringPrependValueModificationTest {
 
     /** Test prepend with empty string */
     @Test
-    public void testPrependEmptyString() {
+    void testPrependEmptyString() {
         StringPrependValueModification modifier = new StringPrependValueModification("");
         modifiableString.setModifications(modifier);
         assertEquals(originalString, modifiableString.getValue());
@@ -43,7 +43,7 @@ public class StringPrependValueModificationTest {
 
     /** Test prepend to empty string */
     @Test
-    public void testPrependToEmptyString() {
+    void testPrependToEmptyString() {
         ModifiableString emptyString = new ModifiableString();
         emptyString.setOriginalValue("");
 
@@ -55,7 +55,7 @@ public class StringPrependValueModificationTest {
 
     /** Test prepend to null string */
     @Test
-    public void testPrependToNullString() {
+    void testPrependToNullString() {
         ModifiableString nullString = new ModifiableString();
         nullString.setOriginalValue(null);
 
@@ -67,7 +67,7 @@ public class StringPrependValueModificationTest {
 
     /** Test that null prepend value is not allowed */
     @Test
-    public void testNullPrependValue() {
+    void testNullPrependValue() {
         assertThrows(
                 NullPointerException.class,
                 () -> {
@@ -78,7 +78,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the getter and setter for prependValue */
     @Test
-    public void testPrependValueGetterAndSetter() {
+    void testPrependValueGetterAndSetter() {
         StringPrependValueModification modifier = new StringPrependValueModification("initial");
         assertEquals("initial", modifier.getPrependValue());
 
@@ -95,7 +95,7 @@ public class StringPrependValueModificationTest {
 
     /** Test prepend with special characters */
     @Test
-    public void testPrependWithSpecialCharacters() {
+    void testPrependWithSpecialCharacters() {
         String specialChars = "@#$%^&*()";
         StringPrependValueModification modifier = new StringPrependValueModification(specialChars);
         modifiableString.setModifications(modifier);
@@ -104,7 +104,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the equals method */
     @Test
-    public void testEqualsMethod() {
+    void testEqualsMethod() {
         StringPrependValueModification mod1 = new StringPrependValueModification("value");
         StringPrependValueModification mod2 = new StringPrependValueModification("value");
         StringPrependValueModification mod3 = new StringPrependValueModification("different");
@@ -125,7 +125,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the hashCode method */
     @Test
-    public void testHashCodeMethod() {
+    void testHashCodeMethod() {
         StringPrependValueModification mod1 = new StringPrependValueModification("value");
         StringPrependValueModification mod2 = new StringPrependValueModification("value");
 
@@ -139,7 +139,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the toString method */
     @Test
-    public void testToStringMethod() {
+    void testToStringMethod() {
         StringPrependValueModification modifier = new StringPrependValueModification("test");
         String toString = modifier.toString();
 
@@ -149,7 +149,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the copy constructor */
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         StringPrependValueModification original = new StringPrependValueModification("original");
         StringPrependValueModification copy = new StringPrependValueModification(original);
 
@@ -164,7 +164,7 @@ public class StringPrependValueModificationTest {
 
     /** Test the createCopy method */
     @Test
-    public void testCreateCopyMethod() {
+    void testCreateCopyMethod() {
         StringPrependValueModification original = new StringPrependValueModification("original");
         StringPrependValueModification copy = original.createCopy();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class ArrayConverterTest {
+class ArrayConverterTest {
 
     /** Test of longToUint64Bytes method, of class ArrayConverter. */
     @Test
-    public void testLongToUint64Bytes() {
+    void testLongToUint64Bytes() {
         long testValue = 0x0123456789ABCDEFL;
         byte[] result = ArrayConverter.longToUint64Bytes(testValue);
         byte[] expected = {
@@ -52,7 +52,7 @@ public class ArrayConverterTest {
 
     /** Test of longToUint32Bytes method, of class ArrayConverter. */
     @Test
-    public void testLongToUint32Bytes() {
+    void testLongToUint32Bytes() {
         long testValue = 0x89ABCDEFL;
         byte[] result = ArrayConverter.longToUint32Bytes(testValue);
         byte[] expected = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
@@ -84,7 +84,7 @@ public class ArrayConverterTest {
 
     /** Test of intToBytes method, of class ArrayConverter. */
     @Test
-    public void testIntToBytes() {
+    void testIntToBytes() {
         int toParse = 5717;
         byte[] result = ArrayConverter.intToBytes(toParse, 2);
         assertArrayEquals(
@@ -106,7 +106,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testIntToBytesOverflow() {
+    void testIntToBytesOverflow() {
         int toParse = 5717;
         byte[] result = ArrayConverter.intToBytes(toParse, 5);
         assertArrayEquals(
@@ -117,7 +117,7 @@ public class ArrayConverterTest {
 
     /** Test of intToBytes method, of class ArrayConverter. */
     @Test
-    public void testLongToBytes() {
+    void testLongToBytes() {
         long toParse = 5717;
         byte[] result = ArrayConverter.longToBytes(toParse, 2);
         assertArrayEquals(
@@ -127,7 +127,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testLongToBytesOverflow() {
+    void testLongToBytesOverflow() {
         int toParse = 5717;
         byte[] result = ArrayConverter.longToBytes(toParse, 10);
         assertArrayEquals(
@@ -139,7 +139,7 @@ public class ArrayConverterTest {
 
     /** Test longToBytes with invalid size parameter (less than 1). */
     @Test
-    public void testLongToBytesWithInvalidSize() {
+    void testLongToBytesWithInvalidSize() {
         int value = 42;
         // Test with size 0
         assertThrows(
@@ -156,7 +156,7 @@ public class ArrayConverterTest {
 
     /** Test of bytesToInt method, of class ArrayConverter. */
     @Test
-    public void testBytesToInt() {
+    void testBytesToInt() {
         byte[] toParse = {0x16, 0x55};
         int expectedResult = 5717;
         assertEquals(
@@ -195,7 +195,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testModifiableVariableToHexString() {
+    void testModifiableVariableToHexString() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null),
@@ -203,7 +203,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testConcatatenateGenericArray() {
+    void testConcatatenateGenericArray() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> ArrayConverter.concatenate(new Object[][] {}),
@@ -212,7 +212,7 @@ public class ArrayConverterTest {
 
     /** Test of bytesToLong method, of class ArrayConverter. */
     @Test
-    public void testBytesToLong() {
+    void testBytesToLong() {
         byte[] toParse = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
         };
@@ -267,7 +267,7 @@ public class ArrayConverterTest {
 
     /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
-    public void testBytesToHexString_byteArr() {
+    void testBytesToHexString_byteArr() {
         byte[] toTest = {0x00, 0x11, 0x22, 0x33, 0x44};
         assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
@@ -307,7 +307,7 @@ public class ArrayConverterTest {
 
     /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
-    public void testBytesToHexString_byteArr_boolean() {
+    void testBytesToHexString_byteArr_boolean() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
             0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01,
@@ -329,7 +329,7 @@ public class ArrayConverterTest {
 
     /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
-    public void testBytesToHexString_3args() {
+    void testBytesToHexString_3args() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
             0x0E, 0x0F
@@ -381,7 +381,7 @@ public class ArrayConverterTest {
 
     /** Test ArrayConverter.bytesToRawHexString(). */
     @Test
-    public void testBytesToRawHexString() {
+    void testBytesToRawHexString() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
             0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01,
@@ -406,7 +406,7 @@ public class ArrayConverterTest {
 
     /** Test of concatenate method, of class ArrayConverter. */
     @Test
-    public void testConcatenate_GenericType() {
+    void testConcatenate_GenericType() {
         String[] array1 = {"a", "b", "c"};
         String[] array2 = {"d", "e", "f"};
         String[] array3 = {"g", "h"};
@@ -452,7 +452,7 @@ public class ArrayConverterTest {
 
     /** Test of concatenate method, of class ArrayConverter. */
     @Test
-    public void testConcatenate_byteArrArr() {
+    void testConcatenate_byteArrArr() {
         byte[] array1 = {0x01, 0x02, 0x03};
         byte[] array2 = {0x04, 0x05, 0x06};
         byte[] array3 = {0x07, 0x08};
@@ -550,7 +550,7 @@ public class ArrayConverterTest {
 
     /** Test of makeArrayNonZero method, of class ArrayConverter. */
     @Test
-    public void testMakeArrayNonZero() {
+    void testMakeArrayNonZero() {
         // Test with array containing zeros
         byte[] testArray = {0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00};
         byte[] expectedArray = {0x01, 0x01, 0x01, 0x02, 0x01, 0x03, 0x01};
@@ -590,7 +590,7 @@ public class ArrayConverterTest {
 
     /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
     @Test
-    public void testBigIntegerToByteArray_3args() {
+    void testBigIntegerToByteArray_3args() {
         // Test with expected length and remove sign byte
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
 
@@ -639,7 +639,7 @@ public class ArrayConverterTest {
 
     /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
     @Test
-    public void testBigIntegerToByteArray_BigInteger() {
+    void testBigIntegerToByteArray_BigInteger() {
         // Test with simple positive value
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
         byte[] expected = ArrayConverter.hexStringToByteArray("ABCDEF1234567890");
@@ -669,7 +669,7 @@ public class ArrayConverterTest {
 
     /** Test of convertListToArray method, of class ArrayConverter. */
     @Test
-    public void testConvertListToArray() {
+    void testConvertListToArray() {
         List<BigInteger> testList = new ArrayList<>();
         testList.add(BigInteger.valueOf(1));
         testList.add(BigInteger.valueOf(2));
@@ -714,7 +714,7 @@ public class ArrayConverterTest {
 
     /** Test of hexStringToByteArray method, of class ArrayConverter. */
     @Test
-    public void testHexStringToByteArray() {
+    void testHexStringToByteArray() {
         String hex = "01";
         assertArrayEquals(
                 new byte[] {0x01},
@@ -745,7 +745,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testBigIntegerToNullPaddedByteArray() {
+    void testBigIntegerToNullPaddedByteArray() {
         BigInteger test = new BigInteger("1D42C86F7923DFEC", 16);
 
         assertArrayEquals(
@@ -769,7 +769,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testLongToUint48Bytes() {
+    void testLongToUint48Bytes() {
         long testValue = 0x0000123456789ABCL;
         byte[] expectedResult = ArrayConverter.hexStringToByteArray("123456789ABC");
 
@@ -792,7 +792,7 @@ public class ArrayConverterTest {
      * methods should be visible in the other tests since the methods just pass the .getValue().
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray() {
+    void testBytesToHexString_ModifiableByteArray() {
         ModifiableByteArray toTest = new ModifiableByteArray();
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -846,7 +846,7 @@ public class ArrayConverterTest {
      * ArrayConverter.
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray_3args() {
+    void testBytesToHexString_ModifiableByteArray_3args() {
         ModifiableByteArray toTest = new ModifiableByteArray();
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -912,7 +912,7 @@ public class ArrayConverterTest {
      * ArrayConverter.
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray_boolean() {
+    void testBytesToHexString_ModifiableByteArray_boolean() {
         ModifiableByteArray toTest = new ModifiableByteArray();
 
         // Test a short array (5 bytes) with pretty printing disabled
@@ -974,7 +974,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testModifiableByteArrayWithNullValue() {
+    void testModifiableByteArrayWithNullValue() {
         // Create a ModifiableByteArray with a null value
         ModifiableByteArray mba = new ModifiableByteArray();
 
@@ -999,7 +999,7 @@ public class ArrayConverterTest {
 
     /** Test of reverseByteOrder method, of class ArrayConverter. */
     @Test
-    public void testReverseByteOrder() {
+    void testReverseByteOrder() {
         byte[] array = {0x00, 0x01, 0x02, 0x03, 0x04};
 
         assertArrayEquals(
@@ -1021,7 +1021,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testBigIntegerReconversion() {
+    void testBigIntegerReconversion() {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             BigInteger b = new BigInteger(1024 + r.nextInt(1000), r);
@@ -1032,14 +1032,14 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testBigIntegerToByteArrayWithZero() {
+    void testBigIntegerToByteArrayWithZero() {
         // Test with BigInteger.ZERO
         byte[] result = ArrayConverter.bigIntegerToByteArray(BigInteger.ZERO);
         assertArrayEquals(new byte[0], result, "BigInteger.ZERO should convert to new byte[0]");
     }
 
     @Test
-    public void testByteToUnsignedInt() {
+    void testByteToUnsignedInt() {
         // Test with positive byte values (0-127)
         assertEquals(
                 0,
@@ -1070,7 +1070,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testUInt64BytesToLong() {
+    void testUInt64BytesToLong() {
         // Test with normal values
         byte[] testBytes = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
@@ -1115,7 +1115,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testUInt32BytesToLong() {
+    void testUInt32BytesToLong() {
         // Test with normal values
         byte[] testBytes = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
         long expected = 0x89ABCDEFL;
@@ -1166,7 +1166,7 @@ public class ArrayConverterTest {
     }
 
     @Test
-    public void testIntegerReconversion() {
+    void testIntegerReconversion() {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             Integer b = r.nextInt();
@@ -1178,7 +1178,7 @@ public class ArrayConverterTest {
 
     /** Test of indexOf method, of class ArrayConverter. */
     @Test
-    public void testIndexOf() {
+    void testIndexOf() {
         byte[] outerArray = ArrayConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
         byte[] innerArray1 = ArrayConverter.hexStringToByteArray("BBCCDD");
         byte[] innerArray2 = ArrayConverter.hexStringToByteArray("BBCCDDEE");

--- a/src/test/java/de/rub/nds/modifiablevariable/util/BadFixedRandomTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/BadFixedRandomTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 /** Tests for the {@link BadFixedRandom} class. */
-public class BadFixedRandomTest {
+class BadFixedRandomTest {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         byte fixedValue = 42;
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -29,7 +29,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testNextBytesWithZeroLength() {
+    void testNextBytesWithZeroLength() {
         byte fixedValue = 42;
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -42,7 +42,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testNextBytesWithLargeArray() {
+    void testNextBytesWithLargeArray() {
         byte fixedValue = (byte) 0xFF; // Using -1 in two's complement
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -57,7 +57,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testMultipleNextBytesCall() {
+    void testMultipleNextBytesCall() {
         byte fixedValue = 123;
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -80,7 +80,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testSetSeed() {
+    void testSetSeed() {
         byte fixedValue = 77;
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -103,7 +103,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testNegativeFixedValue() {
+    void testNegativeFixedValue() {
         byte fixedValue = -128; // Minimum value for a byte
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 
@@ -116,7 +116,7 @@ public class BadFixedRandomTest {
     }
 
     @Test
-    public void testZeroFixedValue() {
+    void testZeroFixedValue() {
         byte fixedValue = 0;
         BadFixedRandom badFixedRandom = new BadFixedRandom(fixedValue);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/BadRandomTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/BadRandomTest.java
@@ -13,10 +13,10 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 /** Tests for the {@link BadRandom} class. */
-public class BadRandomTest {
+class BadRandomTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         BadRandom badRandom = new BadRandom();
 
         // The underlying Random should be initialized with seed 0
@@ -29,7 +29,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testConstructorWithRandom() {
+    void testConstructorWithRandom() {
         // Create a BadRandom with two different Random instances with the same seed
         Random random1 = new Random(42);
         BadRandom badRandom1 = new BadRandom(random1);
@@ -45,7 +45,7 @@ public class BadRandomTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testDeprecatedConstructorWithRandomAndSeed() {
+    void testDeprecatedConstructorWithRandomAndSeed() {
         // Test that the deprecated constructor works
         // Use a fresh Random for each BadRandom to ensure we're testing functionality
         Random random1 = new Random(42);
@@ -72,7 +72,7 @@ public class BadRandomTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testDeprecatedConstructorWithRandomAndSpiAndProvider() {
+    void testDeprecatedConstructorWithRandomAndSpiAndProvider() {
         // Test that the deprecated constructor works
         Random random1 = new Random(42);
         BadRandom badRandom = new BadRandom(random1, null, null);
@@ -94,7 +94,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testGenerateSeed() {
+    void testGenerateSeed() {
         BadRandom badRandom = new BadRandom();
         int numBytes = 10;
         byte[] seed = badRandom.generateSeed(numBytes);
@@ -109,7 +109,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testNextBytes() {
+    void testNextBytes() {
         BadRandom badRandom = new BadRandom();
         byte[] bytes = new byte[10];
         badRandom.nextBytes(bytes);
@@ -123,7 +123,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testSetSeedLong() {
+    void testSetSeedLong() {
         BadRandom badRandom1 = new BadRandom();
         BadRandom badRandom2 = new BadRandom();
 
@@ -141,7 +141,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testSetSeedBytes() {
+    void testSetSeedBytes() {
         BadRandom badRandom = new BadRandom();
         // Get some values before setting the seed
         int val1 = badRandom.nextInt();
@@ -155,7 +155,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testGetAlgorithm() {
+    void testGetAlgorithm() {
         BadRandom badRandom = new BadRandom();
         String algorithm = badRandom.getAlgorithm();
 
@@ -165,7 +165,7 @@ public class BadRandomTest {
     }
 
     @Test
-    public void testNumericMethods() {
+    void testNumericMethods() {
         BadRandom badRandom1 = new BadRandom();
         BadRandom badRandom2 = new BadRandom();
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ComparableByteArrayTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ComparableByteArrayTest.java
@@ -15,10 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class ComparableByteArrayTest {
+class ComparableByteArrayTest {
 
     @Test
-    public void testConstructorAndGetters() {
+    void testConstructorAndGetters() {
         byte[] array = new byte[] {1, 2, 3, 4, 5};
         ComparableByteArray comparableArray = new ComparableByteArray(array);
 
@@ -26,7 +26,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testSetArray() {
+    void testSetArray() {
         byte[] initialArray = new byte[] {1, 2, 3};
         ComparableByteArray comparableArray = new ComparableByteArray(initialArray);
 
@@ -37,7 +37,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithSameContent() {
+    void testEqualsWithSameContent() {
         byte[] array1 = new byte[] {1, 2, 3, 4, 5};
         byte[] array2 = new byte[] {1, 2, 3, 4, 5}; // Same content but different object
 
@@ -53,7 +53,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithDifferentContent() {
+    void testEqualsWithDifferentContent() {
         byte[] array1 = new byte[] {1, 2, 3, 4, 5};
         byte[] array2 = new byte[] {1, 2, 3, 4, 6}; // Different at last position
 
@@ -69,7 +69,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithDifferentLength() {
+    void testEqualsWithDifferentLength() {
         byte[] array1 = new byte[] {1, 2, 3};
         byte[] array2 = new byte[] {1, 2, 3, 4}; // Extra element
 
@@ -82,7 +82,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithSameInstance() {
+    void testEqualsWithSameInstance() {
         byte[] array = new byte[] {1, 2, 3, 4, 5};
         ComparableByteArray comparable = new ComparableByteArray(array);
 
@@ -91,7 +91,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithNull() {
+    void testEqualsWithNull() {
         byte[] array = new byte[] {1, 2, 3, 4, 5};
         ComparableByteArray comparable = new ComparableByteArray(array);
 
@@ -100,7 +100,7 @@ public class ComparableByteArrayTest {
     }
 
     @Test
-    public void testEqualsWithDifferentClass() {
+    void testEqualsWithDifferentClass() {
         byte[] array = new byte[] {1, 2, 3, 4, 5};
         ComparableByteArray comparable = new ComparableByteArray(array);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/DataConverterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/DataConverterTest.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class DataConverterTest {
+class DataConverterTest {
 
     /** Test of longToUint64Bytes method, of class DataConverter. */
     @Test
-    public void testLongToUint64Bytes() {
+    void testLongToUint64Bytes() {
         long testValue = 0x0123456789ABCDEFL;
         byte[] result = DataConverter.longToUint64Bytes(testValue);
         byte[] expected = {
@@ -52,7 +52,7 @@ public class DataConverterTest {
 
     /** Test of longToUint32Bytes method, of class DataConverter. */
     @Test
-    public void testLongToUint32Bytes() {
+    void testLongToUint32Bytes() {
         long testValue = 0x89ABCDEFL;
         byte[] result = DataConverter.longToUint32Bytes(testValue);
         byte[] expected = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
@@ -84,7 +84,7 @@ public class DataConverterTest {
 
     /** Test of intToBytes method, of class DataConverter. */
     @Test
-    public void testIntToBytes() {
+    void testIntToBytes() {
         int toParse = 5717;
         byte[] result = DataConverter.intToBytes(toParse, 2);
         assertArrayEquals(
@@ -106,7 +106,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testIntToBytesOverflow() {
+    void testIntToBytesOverflow() {
         int toParse = 5717;
         byte[] result = DataConverter.intToBytes(toParse, 5);
         assertArrayEquals(
@@ -117,7 +117,7 @@ public class DataConverterTest {
 
     /** Test of intToBytes method, of class DataConverter. */
     @Test
-    public void testLongToBytes() {
+    void testLongToBytes() {
         long toParse = 5717;
         byte[] result = DataConverter.longToBytes(toParse, 2);
         assertArrayEquals(
@@ -127,7 +127,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testLongToBytesOverflow() {
+    void testLongToBytesOverflow() {
         int toParse = 5717;
         byte[] result = DataConverter.longToBytes(toParse, 10);
         assertArrayEquals(
@@ -139,7 +139,7 @@ public class DataConverterTest {
 
     /** Test longToBytes with invalid size parameter (less than 1). */
     @Test
-    public void testLongToBytesWithInvalidSize() {
+    void testLongToBytesWithInvalidSize() {
         int value = 42;
         // Test with size 0
         assertThrows(
@@ -156,7 +156,7 @@ public class DataConverterTest {
 
     /** Test of bytesToInt method, of class DataConverter. */
     @Test
-    public void testBytesToInt() {
+    void testBytesToInt() {
         byte[] toParse = {0x16, 0x55};
         int expectedResult = 5717;
         assertEquals(
@@ -195,7 +195,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testModifiableVariableToHexString() {
+    void testModifiableVariableToHexString() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> DataConverter.bytesToHexString((ModifiableByteArray) null),
@@ -203,7 +203,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testConcatatenateGenericArray() {
+    void testConcatatenateGenericArray() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> DataConverter.concatenate(new Object[][] {}),
@@ -212,7 +212,7 @@ public class DataConverterTest {
 
     /** Test of bytesToLong method, of class DataConverter. */
     @Test
-    public void testBytesToLong() {
+    void testBytesToLong() {
         byte[] toParse = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
         };
@@ -264,7 +264,7 @@ public class DataConverterTest {
 
     /** Test of bytesToHexString method, of class DataConverter. */
     @Test
-    public void testBytesToHexString_byteArr() {
+    void testBytesToHexString_byteArr() {
         byte[] toTest = {0x00, 0x11, 0x22, 0x33, 0x44};
         assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
@@ -304,7 +304,7 @@ public class DataConverterTest {
 
     /** Test of bytesToHexString method, of class DataConverter. */
     @Test
-    public void testBytesToHexString_byteArr_boolean() {
+    void testBytesToHexString_byteArr_boolean() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
             0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01,
@@ -326,7 +326,7 @@ public class DataConverterTest {
 
     /** Test of bytesToHexString method, of class DataConverter. */
     @Test
-    public void testBytesToHexString_3args() {
+    void testBytesToHexString_3args() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
             0x0E, 0x0F
@@ -378,7 +378,7 @@ public class DataConverterTest {
 
     /** Test DataConverter.bytesToRawHexString(). */
     @Test
-    public void testBytesToRawHexString() {
+    void testBytesToRawHexString() {
         byte[] toTest = {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
             0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01,
@@ -403,7 +403,7 @@ public class DataConverterTest {
 
     /** Test of concatenate method, of class DataConverter. */
     @Test
-    public void testConcatenate_GenericType() {
+    void testConcatenate_GenericType() {
         String[] array1 = {"a", "b", "c"};
         String[] array2 = {"d", "e", "f"};
         String[] array3 = {"g", "h"};
@@ -449,7 +449,7 @@ public class DataConverterTest {
 
     /** Test of concatenate method, of class DataConverter. */
     @Test
-    public void testConcatenate_byteArrArr() {
+    void testConcatenate_byteArrArr() {
         byte[] array1 = {0x01, 0x02, 0x03};
         byte[] array2 = {0x04, 0x05, 0x06};
         byte[] array3 = {0x07, 0x08};
@@ -547,7 +547,7 @@ public class DataConverterTest {
 
     /** Test of makeArrayNonZero method, of class DataConverter. */
     @Test
-    public void testMakeArrayNonZero() {
+    void testMakeArrayNonZero() {
         // Test with array containing zeros
         byte[] testArray = {0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00};
         byte[] expectedArray = {0x01, 0x01, 0x01, 0x02, 0x01, 0x03, 0x01};
@@ -587,7 +587,7 @@ public class DataConverterTest {
 
     /** Test of bigIntegerToByteArray method, of class DataConverter. */
     @Test
-    public void testBigIntegerToByteArray_3args() {
+    void testBigIntegerToByteArray_3args() {
         // Test with expected length and remove sign byte
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
 
@@ -636,7 +636,7 @@ public class DataConverterTest {
 
     /** Test of bigIntegerToByteArray method, of class DataConverter. */
     @Test
-    public void testBigIntegerToByteArray_BigInteger() {
+    void testBigIntegerToByteArray_BigInteger() {
         // Test with simple positive value
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
         byte[] expected = DataConverter.hexStringToByteArray("ABCDEF1234567890");
@@ -666,7 +666,7 @@ public class DataConverterTest {
 
     /** Test of convertListToArray method, of class DataConverter. */
     @Test
-    public void testConvertListToArray() {
+    void testConvertListToArray() {
         List<BigInteger> testList = new ArrayList<>();
         testList.add(BigInteger.valueOf(1));
         testList.add(BigInteger.valueOf(2));
@@ -711,7 +711,7 @@ public class DataConverterTest {
 
     /** Test of hexStringToByteArray method, of class DataConverter. */
     @Test
-    public void testHexStringToByteArray() {
+    void testHexStringToByteArray() {
         String hex = "01";
         assertArrayEquals(
                 new byte[] {0x01},
@@ -742,7 +742,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testBigIntegerToNullPaddedByteArray() {
+    void testBigIntegerToNullPaddedByteArray() {
         BigInteger test = new BigInteger("1D42C86F7923DFEC", 16);
 
         assertArrayEquals(
@@ -766,7 +766,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testLongToUint48Bytes() {
+    void testLongToUint48Bytes() {
         long testValue = 0x0000123456789ABCL;
         byte[] expectedResult = DataConverter.hexStringToByteArray("123456789ABC");
 
@@ -789,7 +789,7 @@ public class DataConverterTest {
      * methods should be visible in the other tests since the methods just pass the .getValue().
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray() {
+    void testBytesToHexString_ModifiableByteArray() {
         ModifiableByteArray toTest = new ModifiableByteArray();
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -843,7 +843,7 @@ public class DataConverterTest {
      * DataConverter.
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray_3args() {
+    void testBytesToHexString_ModifiableByteArray_3args() {
         ModifiableByteArray toTest = new ModifiableByteArray();
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -909,7 +909,7 @@ public class DataConverterTest {
      * DataConverter.
      */
     @Test
-    public void testBytesToHexString_ModifiableByteArray_boolean() {
+    void testBytesToHexString_ModifiableByteArray_boolean() {
         ModifiableByteArray toTest = new ModifiableByteArray();
 
         // Test a short array (5 bytes) with pretty printing disabled
@@ -971,7 +971,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testModifiableByteArrayWithNullValue() {
+    void testModifiableByteArrayWithNullValue() {
         // Create a ModifiableByteArray with a null value
         ModifiableByteArray mba = new ModifiableByteArray();
 
@@ -996,7 +996,7 @@ public class DataConverterTest {
 
     /** Test of reverseByteOrder method, of class DataConverter. */
     @Test
-    public void testReverseByteOrder() {
+    void testReverseByteOrder() {
         byte[] array = {0x00, 0x01, 0x02, 0x03, 0x04};
 
         assertArrayEquals(
@@ -1018,7 +1018,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testBigIntegerReconversion() {
+    void testBigIntegerReconversion() {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             BigInteger b = new BigInteger(1024 + r.nextInt(1000), r);
@@ -1029,14 +1029,14 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testBigIntegerToByteArrayWithZero() {
+    void testBigIntegerToByteArrayWithZero() {
         // Test with BigInteger.ZERO
         byte[] result = DataConverter.bigIntegerToByteArray(BigInteger.ZERO);
         assertArrayEquals(new byte[0], result, "BigInteger.ZERO should convert to new byte[0]");
     }
 
     @Test
-    public void testByteToUnsignedInt() {
+    void testByteToUnsignedInt() {
         // Test with positive byte values (0-127)
         assertEquals(
                 0,
@@ -1067,7 +1067,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testUInt64BytesToLong() {
+    void testUInt64BytesToLong() {
         // Test with normal values
         byte[] testBytes = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
@@ -1112,7 +1112,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testUInt32BytesToLong() {
+    void testUInt32BytesToLong() {
         // Test with normal values
         byte[] testBytes = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
         long expected = 0x89ABCDEFL;
@@ -1163,7 +1163,7 @@ public class DataConverterTest {
     }
 
     @Test
-    public void testIntegerReconversion() {
+    void testIntegerReconversion() {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             Integer b = r.nextInt();
@@ -1175,7 +1175,7 @@ public class DataConverterTest {
 
     /** Test of indexOf method, of class DataConverter. */
     @Test
-    public void testIndexOf() {
+    void testIndexOf() {
         byte[] outerArray = DataConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
         byte[] innerArray1 = DataConverter.hexStringToByteArray("BBCCDD");
         byte[] innerArray2 = DataConverter.hexStringToByteArray("BBCCDDEE");

--- a/src/test/java/de/rub/nds/modifiablevariable/util/IllegalStringAdapterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/IllegalStringAdapterTest.java
@@ -15,13 +15,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
-public class IllegalStringAdapterTest {
+class IllegalStringAdapterTest {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
     /** Test of unmarshal method, of class IllegalStringAdapter. */
     @Test
-    public void testUnmarshal() {
+    void testUnmarshal() {
         IllegalStringAdapter instance = new IllegalStringAdapter();
         byte[] data = new byte[256];
         for (int i = 0; i < data.length; i++) {

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableAnalyzerTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableAnalyzerTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
  * <p>Tests all public methods of the ModifiableVariableAnalyzer class with various inputs including
  * edge cases like null objects, empty collections, and nested object hierarchies.
  */
-public class ModifiableVariableAnalyzerTest {
+class ModifiableVariableAnalyzerTest {
 
     private SimpleClassWithModVariables simpleObject;
     private ComplexClassWithModVariables complexObject;
@@ -38,7 +38,7 @@ public class ModifiableVariableAnalyzerTest {
     private ClassWithNoModVariables emptyObject;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         // Initialize test objects
         simpleObject = new SimpleClassWithModVariables();
         simpleObject.bi = new ModifiableBigInteger();
@@ -68,7 +68,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test of getAllModifiableVariableFields method with a simple object. */
     @Test
-    public void testGetAllModifiableVariableFields() {
+    void testGetAllModifiableVariableFields() {
         String[] fieldNames = {"bi", "array", "i"};
         List<Field> fields =
                 ModifiableVariableAnalyzer.getAllModifiableVariableFields(simpleObject);
@@ -87,14 +87,14 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableFields with object having no modifiable variables. */
     @Test
-    public void testGetAllModifiableVariableFieldsEmpty() {
+    void testGetAllModifiableVariableFieldsEmpty() {
         List<Field> fields = ModifiableVariableAnalyzer.getAllModifiableVariableFields(emptyObject);
         assertTrue(fields.isEmpty(), "Empty object should have no modifiable fields");
     }
 
     /** Test of getRandomModifiableVariableField method. */
     @Test
-    public void testGetRandomModifiableVariableField() {
+    void testGetRandomModifiableVariableField() {
         // Test with object containing modifiable variables
         Field randomField =
                 ModifiableVariableAnalyzer.getRandomModifiableVariableField(simpleObject);
@@ -112,7 +112,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test of isModifiableVariableHolder method. */
     @Test
-    public void testIsModifiableVariableHolder() {
+    void testIsModifiableVariableHolder() {
         // Test with object containing modifiable variables
         assertTrue(
                 ModifiableVariableAnalyzer.isModifiableVariableHolder(simpleObject),
@@ -132,7 +132,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test of getAllModifiableVariableFieldsRecursively method with simple object. */
     @Test
-    public void testGetAllModifiableVariableFieldsRecursively() {
+    void testGetAllModifiableVariableFieldsRecursively() {
         // Test with simple object
         List<ModifiableVariableField> fields =
                 ModifiableVariableAnalyzer.getAllModifiableVariableFieldsRecursively(simpleObject);
@@ -151,7 +151,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableFieldsRecursively with nested objects. */
     @Test
-    public void testGetAllModifiableVariableFieldsRecursivelyNested() {
+    void testGetAllModifiableVariableFieldsRecursivelyNested() {
         List<ModifiableVariableField> fields =
                 ModifiableVariableAnalyzer.getAllModifiableVariableFieldsRecursively(complexObject);
 
@@ -161,7 +161,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableFieldsRecursively with a List. */
     @Test
-    public void testGetAllModifiableVariableFieldsRecursivelyWithList() {
+    void testGetAllModifiableVariableFieldsRecursivelyWithList() {
         List<ModifiableVariableField> fields =
                 ModifiableVariableAnalyzer.getAllModifiableVariableFieldsRecursively(listObject);
 
@@ -172,7 +172,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableFieldsRecursively with an array. */
     @Test
-    public void testGetAllModifiableVariableFieldsRecursivelyWithArray() {
+    void testGetAllModifiableVariableFieldsRecursivelyWithArray() {
         List<ModifiableVariableField> fields =
                 ModifiableVariableAnalyzer.getAllModifiableVariableFieldsRecursively(arrayObject);
 
@@ -182,7 +182,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test that the order of fields is consistent when analyzing the same type of object. */
     @Test
-    public void testGetAllModifiableVariableFieldsRecursivelyOrder() {
+    void testGetAllModifiableVariableFieldsRecursivelyOrder() {
         // Create two identical objects with nested structure
         SimpleClassWithModVariables test1 = new SimpleClassWithModVariables();
         test1.bi = new ModifiableBigInteger();
@@ -210,7 +210,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test of getAllModifiableVariableHoldersRecursively method. */
     @Test
-    public void testGetAllModifiableVariableHoldersRecursively() {
+    void testGetAllModifiableVariableHoldersRecursively() {
         // Test with simple object
         List<ModifiableVariableListHolder> holders =
                 ModifiableVariableAnalyzer.getAllModifiableVariableHoldersRecursively(simpleObject);
@@ -231,7 +231,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableHoldersFromList method. */
     @Test
-    public void testGetAllModifiableVariableHoldersFromList() {
+    void testGetAllModifiableVariableHoldersFromList() {
         // Create a list with two objects containing modifiable variables
         List<Object> testList = new LinkedList<>();
         testList.add(new SimpleClassWithModVariables());
@@ -246,7 +246,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableHoldersFromList with empty list. */
     @Test
-    public void testGetAllModifiableVariableHoldersFromEmptyList() {
+    void testGetAllModifiableVariableHoldersFromEmptyList() {
         List<Object> emptyList = Collections.emptyList();
         List<ModifiableVariableListHolder> holders =
                 ModifiableVariableAnalyzer.getAllModifiableVariableHoldersFromList(emptyList);
@@ -256,7 +256,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableHoldersFromArray method. */
     @Test
-    public void testGetAllModifiableVariableHoldersFromArray() {
+    void testGetAllModifiableVariableHoldersFromArray() {
         // Create an array with two objects containing modifiable variables
         Object[] testArray = new Object[2];
         testArray[0] = new SimpleClassWithModVariables();
@@ -270,7 +270,7 @@ public class ModifiableVariableAnalyzerTest {
 
     /** Test getAllModifiableVariableHoldersFromArray with empty array. */
     @Test
-    public void testGetAllModifiableVariableHoldersFromEmptyArray() {
+    void testGetAllModifiableVariableHoldersFromEmptyArray() {
         Object[] emptyArray = new Object[0];
         List<ModifiableVariableListHolder> holders =
                 ModifiableVariableAnalyzer.getAllModifiableVariableHoldersFromArray(emptyArray);

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableFieldTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableFieldTest.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ModifiableVariableFieldTest {
+class ModifiableVariableFieldTest {
 
     private static class TestClass {
         private ModifiableInteger integerField = new ModifiableInteger(42);
@@ -33,7 +33,7 @@ public class ModifiableVariableFieldTest {
     private Field nonModifiableField;
 
     @BeforeEach
-    public void setUp() throws NoSuchFieldException {
+    void setUp() throws NoSuchFieldException {
         testObject = new TestClass();
         integerField = TestClass.class.getDeclaredField("integerField");
         stringField = TestClass.class.getDeclaredField("stringField");
@@ -41,7 +41,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
 
         assertNotNull(field);
@@ -50,7 +50,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetObject() {
+    void testGetObject() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
 
         Object result = field.getObject();
@@ -59,7 +59,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testSetObject() {
+    void testSetObject() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
         TestClass newObject = new TestClass();
 
@@ -69,7 +69,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetField() {
+    void testGetField() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
 
         Field result = field.getField();
@@ -78,7 +78,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testSetField() {
+    void testSetField() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
 
         field.setField(stringField);
@@ -87,7 +87,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetModifiableVariable_Integer()
+    void testGetModifiableVariable_Integer()
             throws IllegalArgumentException, IllegalAccessException {
         ModifiableVariableField field = new ModifiableVariableField(testObject, integerField);
 
@@ -99,7 +99,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetModifiableVariable_String()
+    void testGetModifiableVariable_String()
             throws IllegalArgumentException, IllegalAccessException {
         ModifiableVariableField field = new ModifiableVariableField(testObject, stringField);
 
@@ -111,7 +111,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetModifiableVariable_NonModifiableField() {
+    void testGetModifiableVariable_NonModifiableField() {
         ModifiableVariableField field = new ModifiableVariableField(testObject, nonModifiableField);
 
         assertThrows(
@@ -122,7 +122,7 @@ public class ModifiableVariableFieldTest {
     }
 
     @Test
-    public void testGetModifiableVariable_NullObject() {
+    void testGetModifiableVariable_NullObject() {
         ModifiableVariableField field = new ModifiableVariableField(null, integerField);
 
         assertThrows(

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableListHolderTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableListHolderTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Tests for the {@link ModifiableVariableListHolder} class. */
-public class ModifiableVariableListHolderTest {
+class ModifiableVariableListHolderTest {
 
     /** Test class with modifiable variable fields for testing. */
     private static class TestClass {
@@ -36,7 +36,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test constructor creates a properly initialized object. */
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         TestClass testObject = new TestClass();
         List<Field> fieldList = new ArrayList<>();
 
@@ -59,7 +59,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test constructor with null object. */
     @Test
-    public void testConstructorWithNullObject() {
+    void testConstructorWithNullObject() {
         List<Field> fieldList = new ArrayList<>();
 
         ModifiableVariableListHolder holder = new ModifiableVariableListHolder(null, fieldList);
@@ -71,7 +71,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test constructor with null fields list. */
     @Test
-    public void testConstructorWithNullFields() {
+    void testConstructorWithNullFields() {
         TestClass testObject = new TestClass();
 
         ModifiableVariableListHolder holder = new ModifiableVariableListHolder(testObject, null);
@@ -82,7 +82,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test constructor with empty fields list. */
     @Test
-    public void testConstructorWithEmptyFields() {
+    void testConstructorWithEmptyFields() {
         TestClass testObject = new TestClass();
         List<Field> fieldList = Collections.emptyList();
 
@@ -97,7 +97,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test setter for object. */
     @Test
-    public void testSetObject() {
+    void testSetObject() {
         TestClass testObject1 = new TestClass();
         TestClass testObject2 = new TestClass();
         List<Field> fieldList = new ArrayList<>();
@@ -112,7 +112,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test setter for fields. */
     @Test
-    public void testSetFields() {
+    void testSetFields() {
         TestClass testObject = new TestClass();
         List<Field> fieldList1 = new ArrayList<>();
         List<Field> fieldList2 = new ArrayList<>();
@@ -137,7 +137,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test setting fields to null. */
     @Test
-    public void testSetFieldsToNull() {
+    void testSetFieldsToNull() {
         TestClass testObject = new TestClass();
         List<Field> fieldList = new ArrayList<>();
 
@@ -157,7 +157,7 @@ public class ModifiableVariableListHolderTest {
 
     /** Test that all fields are actually ModifiableVariable fields. */
     @Test
-    public void testFieldsAreModifiableVariables() {
+    void testFieldsAreModifiableVariables() {
         TestClass testObject = new TestClass();
         testObject.intValue = new ModifiableInteger();
         testObject.stringValue = new ModifiableString();

--- a/src/test/java/de/rub/nds/modifiablevariable/util/RandomHelperTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/RandomHelperTest.java
@@ -15,16 +15,16 @@ import java.util.Random;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-public class RandomHelperTest {
+class RandomHelperTest {
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         // Reset to default random for other tests
         RandomHelper.setRandom(new Random(0));
     }
 
     @Test
-    public void testGetRandom() {
+    void testGetRandom() {
         Random random = RandomHelper.getRandom();
         assertNotNull(random);
 
@@ -37,7 +37,7 @@ public class RandomHelperTest {
     }
 
     @Test
-    public void testSetRandom() {
+    void testSetRandom() {
         Random customRandom = new Random(42);
         RandomHelper.setRandom(customRandom);
 
@@ -51,7 +51,7 @@ public class RandomHelperTest {
     }
 
     @Test
-    public void testGetBadSecureRandom() {
+    void testGetBadSecureRandom() {
         BadRandom badRandom = RandomHelper.getBadSecureRandom();
         assertNotNull(badRandom);
 
@@ -67,7 +67,7 @@ public class RandomHelperTest {
     }
 
     @Test
-    public void testBadRandomImplementation() {
+    void testBadRandomImplementation() {
         BadRandom badRandom = new BadRandom();
 
         // Test default constructor
@@ -96,7 +96,7 @@ public class RandomHelperTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testBadRandomConstructors() {
+    void testBadRandomConstructors() {
         Random customRandom = new Random(123);
 
         // Test constructor with Random and seed
@@ -109,7 +109,7 @@ public class RandomHelperTest {
     }
 
     @Test
-    public void testBadFixedRandom() {
+    void testBadFixedRandom() {
         byte fixedValue = 42; // Using a single byte as per the class implementation
         BadFixedRandom fixedRandom = new BadFixedRandom(fixedValue);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ReflectionHelperTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ReflectionHelperTest.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class ReflectionHelperTest {
+class ReflectionHelperTest {
 
     // Helper method to set private fields using reflection
     private static void setPrivateField(Object object, String fieldName, Object value)
@@ -62,7 +62,7 @@ public class ReflectionHelperTest {
     }
 
     @Test
-    public void testGetFieldsUpTo() {
+    void testGetFieldsUpTo() {
         // Get all fields from ChildClass up to but not including Object
         List<Field> fields = ReflectionHelper.getFieldsUpTo(ChildClass.class, Object.class, null);
 
@@ -104,7 +104,7 @@ public class ReflectionHelperTest {
     }
 
     @Test
-    public void testGetFieldsUpToWithFilter() {
+    void testGetFieldsUpToWithFilter() {
         // Get only String fields
         List<Field> stringFields =
                 ReflectionHelper.getFieldsUpTo(ChildClass.class, Object.class, String.class);
@@ -133,7 +133,7 @@ public class ReflectionHelperTest {
     }
 
     @Test
-    public void testGetValuesFromFieldList() throws IllegalAccessException {
+    void testGetValuesFromFieldList() throws IllegalAccessException {
         ChildClass childClass = new ChildClass();
         // Use reflection to set private fields instead of direct access
         setPrivateField(childClass, "baseField", "BaseValue");
@@ -152,7 +152,7 @@ public class ReflectionHelperTest {
     }
 
     @Test
-    public void testGetParameterizedTypes() {
+    void testGetParameterizedTypes() {
         StringGenericImpl impl = new StringGenericImpl();
         Type[] types = ReflectionHelper.getParameterizedTypes(impl);
 

--- a/src/test/java/de/rub/nds/modifiablevariable/util/StringUtilTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/StringUtilTest.java
@@ -18,17 +18,17 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * <p>Tests all methods and edge cases in the StringUtil class.
  */
-public class StringUtilTest {
+class StringUtilTest {
 
     /** Test backslashEscapeString with null input. */
     @Test
-    public void testBackslashEscapeStringWithNull() {
+    void testBackslashEscapeStringWithNull() {
         assertNull(StringUtil.backslashEscapeString(null), "Null input should return null");
     }
 
     /** Test backslashEscapeString with empty string. */
     @Test
-    public void testBackslashEscapeStringWithEmptyString() {
+    void testBackslashEscapeStringWithEmptyString() {
         assertEquals("", StringUtil.backslashEscapeString(""), "Empty string should remain empty");
     }
 
@@ -45,7 +45,7 @@ public class StringUtilTest {
                 "0123456789",
                 "!@#$%^&*()_+-={}[]|:;'<>,.?/~`"
             })
-    public void testBackslashEscapeStringWithPlainText(String input) {
+    void testBackslashEscapeStringWithPlainText(String input) {
         assertEquals(
                 input,
                 StringUtil.backslashEscapeString(input),
@@ -54,7 +54,7 @@ public class StringUtilTest {
 
     /** Test backslashEscapeString with common escape characters. */
     @Test
-    public void testBackslashEscapeStringWithEscapeChars() {
+    void testBackslashEscapeStringWithEscapeChars() {
         // Test backspace character
         assertEquals(
                 "a\\b",
@@ -88,7 +88,7 @@ public class StringUtilTest {
 
     /** Test backslashEscapeString with non-ASCII and control characters. */
     @Test
-    public void testBackslashEscapeStringWithNonAsciiAndControlChars() {
+    void testBackslashEscapeStringWithNonAsciiAndControlChars() {
         // Test string with various control characters and non-ASCII characters
         assertEquals(
                 "Null byte \\u0000 and bell \\u0007",
@@ -103,7 +103,7 @@ public class StringUtilTest {
 
     /** Test backslashEscapeString with supplementary characters (characters outside BMP). */
     @Test
-    public void testBackslashEscapeStringWithSupplementaryChars() {
+    void testBackslashEscapeStringWithSupplementaryChars() {
         // Test string with emoji and other supplementary characters
         assertEquals(
                 "Emoji: \\uD83D\\uDE00 \\uD83D\\uDE04 \\uD83D\\uDE2D",
@@ -121,7 +121,7 @@ public class StringUtilTest {
      * Test backslashEscapeString with a complex mixed string containing various character types.
      */
     @Test
-    public void testBackslashEscapeStringWithComplexString() {
+    void testBackslashEscapeStringWithComplexString() {
         String input =
                 "ASCII with control chars \n\t\r\f\b\\ and non-ASCII äöü and emoji 👨‍👩‍👧‍👦";
         String expected =
@@ -135,7 +135,7 @@ public class StringUtilTest {
 
     /** Test backslashEscapeString with real-world examples from previous test. */
     @Test
-    public void testBackslashEscapeStringWithExistingExamples() {
+    void testBackslashEscapeStringWithExistingExamples() {
         // Existing test cases for reference and regression
         assertEquals(
                 "String with line-\\nbreak, tab\\tstop and backslash \\\\",
@@ -157,7 +157,7 @@ public class StringUtilTest {
      * edge cases at the boundary of valid code points.
      */
     @Test
-    public void testBackslashEscapeStringWithMaximumValidCodePoint() {
+    void testBackslashEscapeStringWithMaximumValidCodePoint() {
         // Create a StringBuilder with the maximum valid code point
         StringBuilder input = new StringBuilder("Test");
         input.appendCodePoint(Character.MAX_CODE_POINT);

--- a/src/test/java/de/rub/nds/modifiablevariable/util/SuppressingBooleanAdapterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/SuppressingBooleanAdapterTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
-public class SuppressingBooleanAdapterTest {
+class SuppressingBooleanAdapterTest {
 
     @Test
-    public void testSuppressingTrueBooleanAdapter() throws Exception {
+    void testSuppressingTrueBooleanAdapter() throws Exception {
         SuppressingBooleanAdapter adapter = new SuppressingTrueBooleanAdapter();
 
         // Test getValueToSuppress
@@ -34,7 +34,7 @@ public class SuppressingBooleanAdapterTest {
     }
 
     @Test
-    public void testSuppressingFalseBooleanAdapter() throws Exception {
+    void testSuppressingFalseBooleanAdapter() throws Exception {
         SuppressingBooleanAdapter adapter = new SuppressingFalseBooleanAdapter();
 
         // Test getValueToSuppress

--- a/src/test/java/de/rub/nds/modifiablevariable/util/UnformattedByteArrayAdapterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/UnformattedByteArrayAdapterTest.java
@@ -13,17 +13,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class UnformattedByteArrayAdapterTest {
+class UnformattedByteArrayAdapterTest {
 
     private UnformattedByteArrayAdapter adapter;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         adapter = new UnformattedByteArrayAdapter();
     }
 
     @Test
-    public void testMarshal() throws Exception {
+    void testMarshal() throws Exception {
         byte[] input = new byte[] {0x01, 0x02, 0x03, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
         String expected = "01 02 03 AB CD EF";
 
@@ -31,7 +31,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testUnmarshalCompactFormat() throws Exception {
+    void testUnmarshalCompactFormat() throws Exception {
         String input = "0102ABCDEF";
         byte[] expected = new byte[] {0x01, 0x02, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
 
@@ -39,7 +39,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testUnmarshalWithSpaces() throws Exception {
+    void testUnmarshalWithSpaces() throws Exception {
         String input = "01 02 AB CD EF";
         byte[] expected = new byte[] {0x01, 0x02, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
 
@@ -47,7 +47,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testUnmarshalWithNewlinesAndSpaces() throws Exception {
+    void testUnmarshalWithNewlinesAndSpaces() throws Exception {
         String input = "01 02\nAB CD\r\nEF";
         byte[] expected = new byte[] {0x01, 0x02, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
 
@@ -55,7 +55,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testMarshalEmptyArray() throws Exception {
+    void testMarshalEmptyArray() throws Exception {
         byte[] input = new byte[0];
         String expected = "";
 
@@ -63,7 +63,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testUnmarshalEmptyString() throws Exception {
+    void testUnmarshalEmptyString() throws Exception {
         String input = "";
         byte[] expected = new byte[0];
 
@@ -71,7 +71,7 @@ public class UnformattedByteArrayAdapterTest {
     }
 
     @Test
-    public void testUnmarshalOnlyWhitespace() throws Exception {
+    void testUnmarshalOnlyWhitespace() throws Exception {
         String input = " \n\t\r ";
         byte[] expected = new byte[0];
 


### PR DESCRIPTION
## Summary
- Removed unnecessary public modifiers from test classes and methods following JUnit 5 best practices
- Updated 78 test files (4 files already had proper modifiers)
- No functional changes - only visibility modifiers were updated

## Changes
- Test class declarations now use package-private visibility
- Test methods (@Test annotated) now use package-private visibility
- Lifecycle methods (@BeforeEach, @AfterEach, @BeforeAll, @AfterAll) now use package-private visibility
- Inner classes and helper methods now use appropriate visibility
- Kept public modifiers only where required for overriding public methods from parent classes/interfaces

## Test plan
- [x] Run mvn test to ensure all 782 tests still pass
- [x] Verify code compiles successfully with mvn test-compile
- [x] All tests pass without any failures