### PR TITLE
Fix ArrayConverter deprecation warnings

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableHolder.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/ModifiableVariableHolder.java
@@ -7,7 +7,7 @@
  */
 package de.rub.nds.modifiablevariable;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.ReflectionHelper;
 import jakarta.xml.bind.annotation.XmlType;
 import java.io.Serializable;
@@ -194,7 +194,7 @@ public abstract class ModifiableVariableHolder implements Serializable {
                     stringBuilder.append("\t".repeat(Math.max(0, depth)));
                     stringBuilder.append(field.getName());
                     stringBuilder.append(": ");
-                    stringBuilder.append(ArrayConverter.bytesToHexString(temp));
+                    stringBuilder.append(DataConverter.bytesToHexString(temp));
                     stringBuilder.append("\n");
                 }
                 if (tempObject instanceof ModifiableVariableHolder) {

--- a/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/VariableModification.java
@@ -10,7 +10,7 @@ package de.rub.nds.modifiablevariable;
 import static de.rub.nds.modifiablevariable.util.StringUtil.backslashEscapeString;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -137,7 +137,7 @@ public abstract class VariableModification<E> implements Serializable {
             } else {
                 String valueString =
                         switch (value) {
-                            case byte[] bytes -> ArrayConverter.bytesToHexString(bytes);
+                            case byte[] bytes -> DataConverter.bytesToHexString(bytes);
                             case String s -> backslashEscapeString(s);
                             default -> value.toString();
                         };

--- a/src/main/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigInteger.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigInteger.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.biginteger;
 
 import de.rub.nds.modifiablevariable.ModifiableVariable;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.math.BigInteger;
 
@@ -108,7 +108,7 @@ public class ModifiableBigInteger extends ModifiableVariable<BigInteger> {
      * @return The byte array representation of the BigInteger
      */
     public byte[] getByteArray() {
-        return ArrayConverter.bigIntegerToByteArray(getValue());
+        return DataConverter.bigIntegerToByteArray(getValue());
     }
 
     /**
@@ -118,7 +118,7 @@ public class ModifiableBigInteger extends ModifiableVariable<BigInteger> {
      * @return The byte array representation of the BigInteger
      */
     public byte[] getByteArray(int size) {
-        return ArrayConverter.bigIntegerToByteArray(getValue(), size, true);
+        return DataConverter.bigIntegerToByteArray(getValue(), size, true);
     }
 
     /**

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -96,7 +96,7 @@ public class ByteArrayAppendValueModification extends VariableModification<byte[
         if (input == null) {
             return null;
         }
-        return ArrayConverter.concatenate(input, bytesToAppend);
+        return DataConverter.concatenate(input, bytesToAppend);
     }
 
     /**
@@ -167,7 +167,7 @@ public class ByteArrayAppendValueModification extends VariableModification<byte[
     @Override
     public String toString() {
         return "ByteArrayAppendValueModification{bytesToAppend="
-                + ArrayConverter.bytesToHexString(bytesToAppend)
+                + DataConverter.bytesToHexString(bytesToAppend)
                 + "}";
     }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDeleteModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 
@@ -114,7 +114,7 @@ public class ByteArrayDeleteModification extends VariableModification<byte[]> {
         byte[] ret1 = Arrays.copyOf(input, deleteStartPosition);
         if (deleteEndPosition < input.length) {
             byte[] ret2 = Arrays.copyOfRange(input, deleteEndPosition, input.length);
-            return ArrayConverter.concatenate(ret1, ret2);
+            return DataConverter.concatenate(ret1, ret2);
         }
         return ret1;
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -72,7 +72,7 @@ public class ByteArrayDuplicateModification extends VariableModification<byte[]>
         if (input == null) {
             return null;
         }
-        return ArrayConverter.concatenate(input, input);
+        return DataConverter.concatenate(input, input);
     }
 
     /**

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayExplicitValueModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -148,7 +148,7 @@ public class ByteArrayExplicitValueModification extends VariableModification<byt
     public String toString() {
         return "ByteArrayExplicitValueModification{"
                 + "explicitValue="
-                + ArrayConverter.bytesToHexString(explicitValue)
+                + DataConverter.bytesToHexString(explicitValue)
                 + '}';
     }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -118,9 +118,9 @@ public class ByteArrayInsertValueModification extends VariableModification<byte[
         byte[] ret1 = Arrays.copyOf(input, insertPosition);
         if (insertPosition < input.length) {
             byte[] ret2 = Arrays.copyOfRange(input, insertPosition, input.length);
-            return ArrayConverter.concatenate(ret1, bytesToInsert, ret2);
+            return DataConverter.concatenate(ret1, bytesToInsert, ret2);
         }
-        return ArrayConverter.concatenate(ret1, bytesToInsert);
+        return DataConverter.concatenate(ret1, bytesToInsert);
     }
 
     /**
@@ -215,7 +215,7 @@ public class ByteArrayInsertValueModification extends VariableModification<byte[
     public String toString() {
         return "ByteArrayInsertModification{"
                 + "bytesToInsert="
-                + ArrayConverter.bytesToHexString(bytesToInsert)
+                + DataConverter.bytesToHexString(bytesToInsert)
                 + ", startPosition="
                 + startPosition
                 + '}';

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -98,7 +98,7 @@ public class ByteArrayPrependValueModification extends VariableModification<byte
         if (input == null) {
             return null;
         }
-        return ArrayConverter.concatenate(bytesToPrepend, input);
+        return DataConverter.concatenate(bytesToPrepend, input);
     }
 
     /**
@@ -169,7 +169,7 @@ public class ByteArrayPrependValueModification extends VariableModification<byte
     @Override
     public String toString() {
         return "ByteArrayPrependValueModification{bytesToPrepend="
-                + ArrayConverter.bytesToHexString(bytesToPrepend)
+                + DataConverter.bytesToHexString(bytesToPrepend)
                 + "}";
     }
 }

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayXorModification.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -208,7 +208,7 @@ public class ByteArrayXorModification extends VariableModification<byte[]> {
     public String toString() {
         return "ByteArrayXorModification{"
                 + "xor="
-                + ArrayConverter.bytesToHexString(xor)
+                + DataConverter.bytesToHexString(xor)
                 + ", startPosition="
                 + startPosition
                 + '}';

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArray.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArray.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.bytearray;
 
 import de.rub.nds.modifiablevariable.ModifiableVariable;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.UnformattedByteArrayAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -213,7 +213,7 @@ public class ModifiableByteArray extends ModifiableVariable<byte[]> {
     public String toString() {
         return "ModifiableByteArray{"
                 + "originalValue="
-                + (originalValue != null ? ArrayConverter.bytesToHexString(originalValue) : "")
+                + (originalValue != null ? DataConverter.bytesToHexString(originalValue) : "")
                 + innerToString()
                 + '}';
     }

--- a/src/main/java/de/rub/nds/modifiablevariable/integer/ModifiableInteger.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/integer/ModifiableInteger.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.integer;
 
 import de.rub.nds.modifiablevariable.ModifiableVariable;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -111,7 +111,7 @@ public class ModifiableInteger extends ModifiableVariable<Integer> {
      * @return The byte array representation of the integer
      */
     public byte[] getByteArray(int size) {
-        return ArrayConverter.intToBytes(getValue(), size);
+        return DataConverter.intToBytes(getValue(), size);
     }
 
     /**

--- a/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
@@ -7,7 +7,7 @@
  */
 package de.rub.nds.modifiablevariable.logging;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.util.Strings;
  * handling for byte array parameters in log messages. While the standard PatternLayout would format
  * byte arrays using {@link Arrays#toString(byte[])}, which produces output like "[B@1a2b3c4]", this
  * layout intercepts byte array parameters and formats them as readable hexadecimal strings using
- * {@link ArrayConverter#bytesToHexString(byte[])}.
+ * {@link DataConverter#bytesToHexString(byte[])}.
  *
  * <p>The layout supports all standard PatternLayout features including:
  *
@@ -827,7 +827,7 @@ public final class ExtendedPatternLayout extends AbstractStringLayout {
          *         <li>It identifies any byte array parameters in the log message
          *         <li>It locates the default string representation of these byte arrays in the
          *             builder
-         *         <li>It replaces them with formatted hexadecimal strings using ArrayConverter
+         *         <li>It replaces them with formatted hexadecimal strings using DataConverter
          *       </ul>
          * </ol>
          *
@@ -863,13 +863,13 @@ public final class ExtendedPatternLayout extends AbstractStringLayout {
                 for (Object param : event.getMessage().getParameters()) {
 
                     // Replace all ByteArrays with the String representation of the ByteArray
-                    // calculated by the ArrayConverter.
+                    // calculated by the DataConverter.
                     if (param != null && bArrayClass.equals(param.getClass())) {
                         builder.replace(
                                 builder.indexOf(Arrays.toString((byte[]) param)),
                                 builder.indexOf(Arrays.toString((byte[]) param))
                                         + Arrays.toString((byte[]) param).length(),
-                                ArrayConverter.bytesToHexString(
+                                DataConverter.bytesToHexString(
                                         (byte[]) param,
                                         Builder.prettyPrinting,
                                         Builder.initNewLine));

--- a/src/main/java/de/rub/nds/modifiablevariable/longint/ModifiableLong.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/longint/ModifiableLong.java
@@ -8,7 +8,7 @@
 package de.rub.nds.modifiablevariable.longint;
 
 import de.rub.nds.modifiablevariable.ModifiableVariable;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -126,14 +126,14 @@ public class ModifiableLong extends ModifiableVariable<Long> {
     /**
      * Converts the modified long value to a byte array of the specified size.
      *
-     * <p>This method uses {@link ArrayConverter} to convert the current value to a byte array. The
+     * <p>This method uses {@link DataConverter} to convert the current value to a byte array. The
      * resulting array will have the specified size, with padding or truncation as necessary.
      *
      * @param size The desired size of the resulting byte array
      * @return A byte array representation of the current value with the specified size
      */
     public byte[] getByteArray(int size) {
-        return ArrayConverter.longToBytes(getValue(), size);
+        return DataConverter.longToBytes(getValue(), size);
     }
 
     /**

--- a/src/main/java/de/rub/nds/modifiablevariable/util/UnformattedByteArrayAdapter.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/util/UnformattedByteArrayAdapter.java
@@ -61,7 +61,7 @@ public class UnformattedByteArrayAdapter extends XmlAdapter<String, byte[]> {
     @Override
     public byte[] unmarshal(String value) {
         value = value.replaceAll("\\s", "");
-        return ArrayConverter.hexStringToByteArray(value);
+        return DataConverter.hexStringToByteArray(value);
     }
 
     /**
@@ -75,6 +75,6 @@ public class UnformattedByteArrayAdapter extends XmlAdapter<String, byte[]> {
      */
     @Override
     public String marshal(byte[] value) {
-        return ArrayConverter.bytesToHexString(value, false, false);
+        return DataConverter.bytesToHexString(value, false, false);
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArrayTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bytearray/ModifiableByteArrayTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import de.rub.nds.modifiablevariable.ModifiableVariableFactory;
 import de.rub.nds.modifiablevariable.VariableModification;
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -103,7 +103,7 @@ class ModifiableByteArrayTest {
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
 
         byte[] expResult2 = originalValue.clone();
@@ -135,7 +135,7 @@ class ModifiableByteArrayTest {
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
     }
 
@@ -158,7 +158,7 @@ class ModifiableByteArrayTest {
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
     }
 
@@ -176,7 +176,7 @@ class ModifiableByteArrayTest {
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
     }
 
@@ -196,7 +196,7 @@ class ModifiableByteArrayTest {
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
     }
 
@@ -259,7 +259,7 @@ class ModifiableByteArrayTest {
                 new ByteArrayInsertValueModification(modification1, -2 * originalValue.length);
         start.setModifications(modifier);
         byte[] expResult =
-                ArrayConverter.concatenate(
+                DataConverter.concatenate(
                         Arrays.copyOf(originalValue, 1),
                         modification1,
                         Arrays.copyOfRange(originalValue, 1, originalValue.length));
@@ -279,7 +279,7 @@ class ModifiableByteArrayTest {
         modifier = new ByteArrayInsertValueModification(modification1, originalValue.length * 2);
         start.setModifications(modifier);
         expResult =
-                ArrayConverter.concatenate(
+                DataConverter.concatenate(
                         Arrays.copyOf(originalValue, originalValue.length - 1),
                         modification1,
                         Arrays.copyOfRange(
@@ -305,13 +305,13 @@ class ModifiableByteArrayTest {
     @Test
     void testDuplicateModification() {
         LOGGER.info("testDuplicateModification");
-        byte[] expResult = ArrayConverter.concatenate(originalValue, originalValue);
+        byte[] expResult = DataConverter.concatenate(originalValue, originalValue);
 
         VariableModification<byte[]> modifier = new ByteArrayDuplicateModification();
         start.setModifications(modifier);
 
         LOGGER.debug("Expected: {}", expResult);
-        LOGGER.debug("Computed: {}", () -> ArrayConverter.bytesToHexString(start.getValue()));
+        LOGGER.debug("Computed: {}", () -> DataConverter.bytesToHexString(start.getValue()));
         assertArrayEquals(expResult, start.getValue());
     }
 

--- a/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
@@ -9,7 +9,7 @@ package de.rub.nds.modifiablevariable.logging;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.Level;
@@ -78,8 +78,8 @@ class ExtendedPatternLayoutTest {
         // Should NOT contain the default "[B@..." representation
         assertFalse(result.contains("[B@"));
 
-        // Should contain the hex representation from ArrayConverter
-        String expectedHex = ArrayConverter.bytesToHexString(data, false, false);
+        // Should contain the hex representation from DataConverter
+        String expectedHex = DataConverter.bytesToHexString(data, false, false);
         assertTrue(result.contains(expectedHex));
     }
 
@@ -94,8 +94,8 @@ class ExtendedPatternLayoutTest {
         String result = layout.toSerializable(event);
 
         // Should contain both hex representations
-        String expectedHex1 = ArrayConverter.bytesToHexString(data1, false, false);
-        String expectedHex2 = ArrayConverter.bytesToHexString(data2, false, false);
+        String expectedHex1 = DataConverter.bytesToHexString(data1, false, false);
+        String expectedHex2 = DataConverter.bytesToHexString(data2, false, false);
         assertTrue(result.contains(expectedHex1));
         assertTrue(result.contains(expectedHex2));
     }
@@ -115,7 +115,7 @@ class ExtendedPatternLayoutTest {
         String result = layout.toSerializable(event);
 
         // Should contain properly formatted parameters
-        String expectedHex = ArrayConverter.bytesToHexString(data, false, false);
+        String expectedHex = DataConverter.bytesToHexString(data, false, false);
         assertTrue(result.contains(expectedHex));
         assertTrue(result.contains(stringParam));
         assertTrue(result.contains(intParam.toString()));
@@ -134,7 +134,7 @@ class ExtendedPatternLayoutTest {
         String result = layout.toSerializable(event);
 
         // Verify that the hex representation is included
-        assertTrue(result.contains(ArrayConverter.bytesToHexString(data, false, false)));
+        assertTrue(result.contains(DataConverter.bytesToHexString(data, false, false)));
     }
 
     @Test
@@ -153,8 +153,8 @@ class ExtendedPatternLayoutTest {
         // Verify that the array was serialized correctly (shouldn't contain [B@...)
         assertFalse(result.contains("[B@"));
 
-        // Should contain the hex representation from ArrayConverter
-        String expectedHex = ArrayConverter.bytesToHexString(longData, false, false);
+        // Should contain the hex representation from DataConverter
+        String expectedHex = DataConverter.bytesToHexString(longData, false, false);
         assertTrue(result.contains(expectedHex));
     }
 
@@ -171,7 +171,7 @@ class ExtendedPatternLayoutTest {
         assertFalse(result.contains("[B@"));
 
         // Should contain the formatted hex string (use exact bytes for matching)
-        String expectedHex = ArrayConverter.bytesToHexString(data, false, false);
+        String expectedHex = DataConverter.bytesToHexString(data, false, false);
         assertTrue(result.contains(expectedHex));
     }
 
@@ -218,7 +218,7 @@ class ExtendedPatternLayoutTest {
         String result = layout.toSerializable(event);
 
         // Should contain the hex representation of an empty array
-        String expectedHex = ArrayConverter.bytesToHexString(emptyData, false, false);
+        String expectedHex = DataConverter.bytesToHexString(emptyData, false, false);
         assertTrue(result.contains(expectedHex));
     }
 
@@ -324,7 +324,7 @@ class ExtendedPatternLayoutTest {
         String result = layout.toSerializable(event);
 
         // Should contain the hex representation twice (both instances replaced)
-        String expectedHex = ArrayConverter.bytesToHexString(data, false, false);
+        String expectedHex = DataConverter.bytesToHexString(data, false, false);
 
         // Count occurrences of the hex string
         int count = 0;
@@ -354,7 +354,7 @@ class ExtendedPatternLayoutTest {
         // Should NOT contain the default "[B@..." representation
         assertFalse(result.contains("[B@"));
 
-        // Should contain the hex representation from ArrayConverter
+        // Should contain the hex representation from DataConverter
         // (Note: we don't check the exact string)
         assertTrue(result.length() > 2000); // A rough check that conversion happened
     }

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.api.Test;
 
 class ArrayConverterTest {
 
-    /** Test of longToUint64Bytes method, of class DataConverter. */
+    /** Test of longToUint64Bytes method, of class ArrayConverter. */
     @Test
     void testLongToUint64Bytes() {
         long testValue = 0x0123456789ABCDEFL;
-        byte[] result = DataConverter.longToUint64Bytes(testValue);
+        byte[] result = ArrayConverter.longToUint64Bytes(testValue);
         byte[] expected = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
         };
@@ -36,13 +36,13 @@ class ArrayConverterTest {
 
         // Test with zero value
         testValue = 0L;
-        result = DataConverter.longToUint64Bytes(testValue);
+        result = ArrayConverter.longToUint64Bytes(testValue);
         expected = new byte[8]; // All zeros
         assertArrayEquals(expected, result, "The byte array should be all zeros");
 
         // Test with max value
         testValue = -1L; // All bits set to 1 in two's complement (0xFFFFFFFFFFFFFFFF)
-        result = DataConverter.longToUint64Bytes(testValue);
+        result = ArrayConverter.longToUint64Bytes(testValue);
         expected = new byte[8];
         for (int i = 0; i < expected.length; i++) {
             expected[i] = (byte) 0xFF;
@@ -50,24 +50,24 @@ class ArrayConverterTest {
         assertArrayEquals(expected, result, "The byte array should be all FF");
     }
 
-    /** Test of longToUint32Bytes method, of class DataConverter. */
+    /** Test of longToUint32Bytes method, of class ArrayConverter. */
     @Test
     void testLongToUint32Bytes() {
         long testValue = 0x89ABCDEFL;
-        byte[] result = DataConverter.longToUint32Bytes(testValue);
+        byte[] result = ArrayConverter.longToUint32Bytes(testValue);
         byte[] expected = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
 
         assertArrayEquals(expected, result, "The byte array should match the expected 4-bytes");
 
         // Test with zero value
         testValue = 0L;
-        result = DataConverter.longToUint32Bytes(testValue);
+        result = ArrayConverter.longToUint32Bytes(testValue);
         expected = new byte[4]; // All zeros
         assertArrayEquals(expected, result, "The byte array should be all zeros");
 
         // Test with max 32-bit value
         testValue = 0xFFFFFFFFL;
-        result = DataConverter.longToUint32Bytes(testValue);
+        result = ArrayConverter.longToUint32Bytes(testValue);
         expected = new byte[4];
         for (int i = 0; i < expected.length; i++) {
             expected[i] = (byte) 0xFF;
@@ -76,17 +76,17 @@ class ArrayConverterTest {
 
         // Test with value greater than 32 bits (should truncate high bits)
         testValue = 0x0123456789ABCDEFL;
-        result = DataConverter.longToUint32Bytes(testValue);
+        result = ArrayConverter.longToUint32Bytes(testValue);
         expected = new byte[] {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
         assertArrayEquals(
                 expected, result, "The byte array should only contain the lowest 32 bits");
     }
 
-    /** Test of intToBytes method, of class DataConverter. */
+    /** Test of intToBytes method, of class ArrayConverter. */
     @Test
     void testIntToBytes() {
         int toParse = 5717;
-        byte[] result = DataConverter.intToBytes(toParse, 2);
+        byte[] result = ArrayConverter.intToBytes(toParse, 2);
         assertArrayEquals(
                 new byte[] {0x16, 0x55},
                 result,
@@ -95,31 +95,31 @@ class ArrayConverterTest {
         // Test with invalid size parameter (less than 1)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.intToBytes(42, 0),
+                () -> ArrayConverter.intToBytes(42, 0),
                 "Should throw IllegalArgumentException for size 0");
 
         // Test with negative size
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.intToBytes(42, -1),
+                () -> ArrayConverter.intToBytes(42, -1),
                 "Should throw IllegalArgumentException for negative size");
     }
 
     @Test
     void testIntToBytesOverflow() {
         int toParse = 5717;
-        byte[] result = DataConverter.intToBytes(toParse, 5);
+        byte[] result = ArrayConverter.intToBytes(toParse, 5);
         assertArrayEquals(
                 new byte[] {0x00, 0x00, 0x00, 0x16, 0x55},
                 result,
                 "The conversion result of 5717 should be {0x00} {0x00} {0x00} {0x16} {0x55}");
     }
 
-    /** Test of intToBytes method, of class DataConverter. */
+    /** Test of intToBytes method, of class ArrayConverter. */
     @Test
     void testLongToBytes() {
         long toParse = 5717;
-        byte[] result = DataConverter.longToBytes(toParse, 2);
+        byte[] result = ArrayConverter.longToBytes(toParse, 2);
         assertArrayEquals(
                 new byte[] {0x16, 0x55},
                 result,
@@ -129,7 +129,7 @@ class ArrayConverterTest {
     @Test
     void testLongToBytesOverflow() {
         int toParse = 5717;
-        byte[] result = DataConverter.longToBytes(toParse, 10);
+        byte[] result = ArrayConverter.longToBytes(toParse, 10);
         assertArrayEquals(
                 new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x55},
                 result,
@@ -144,24 +144,24 @@ class ArrayConverterTest {
         // Test with size 0
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.longToBytes(value, 0),
+                () -> ArrayConverter.longToBytes(value, 0),
                 "Should throw IllegalArgumentException for size 0");
 
         // Test with negative size
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.longToBytes(value, -1),
+                () -> ArrayConverter.longToBytes(value, -1),
                 "Should throw IllegalArgumentException for negative size");
     }
 
-    /** Test of bytesToInt method, of class DataConverter. */
+    /** Test of bytesToInt method, of class ArrayConverter. */
     @Test
     void testBytesToInt() {
         byte[] toParse = {0x16, 0x55};
         int expectedResult = 5717;
         assertEquals(
                 expectedResult,
-                DataConverter.bytesToInt(toParse),
+                ArrayConverter.bytesToInt(toParse),
                 "The conversion result of {0x16, 0x55} should be 5717");
 
         // Test with empty array
@@ -169,7 +169,7 @@ class ArrayConverterTest {
         expectedResult = 0;
         assertEquals(
                 expectedResult,
-                DataConverter.bytesToInt(toParse),
+                ArrayConverter.bytesToInt(toParse),
                 "Empty array should convert to 0");
 
         // Test with 4 bytes (max allowed)
@@ -177,20 +177,20 @@ class ArrayConverterTest {
         expectedResult = 0x01020304;
         assertEquals(
                 expectedResult,
-                DataConverter.bytesToInt(toParse),
+                ArrayConverter.bytesToInt(toParse),
                 "4-byte array should convert correctly");
 
         // Test with array exceeding allowed length (should throw exception)
         final byte[] oversizedIntArray = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05};
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToInt(oversizedIntArray),
+                () -> ArrayConverter.bytesToInt(oversizedIntArray),
                 "Array > 4 bytes should throw IllegalArgumentException");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToInt(null),
+                () -> ArrayConverter.bytesToInt(null),
                 "Null input should throw IllegalArgumentException");
     }
 
@@ -198,7 +198,7 @@ class ArrayConverterTest {
     void testModifiableVariableToHexString() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((ModifiableByteArray) null),
+                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null),
                 "Null input should throw IllegalArgumentException");
     }
 
@@ -206,11 +206,11 @@ class ArrayConverterTest {
     void testConcatatenateGenericArray() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(new Object[][] {}),
+                () -> ArrayConverter.concatenate(new Object[][] {}),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToLong method, of class DataConverter. */
+    /** Test of bytesToLong method, of class ArrayConverter. */
     @Test
     void testBytesToLong() {
         byte[] toParse = {
@@ -219,24 +219,25 @@ class ArrayConverterTest {
         long expected = 0x0123456789ABCDEFL;
         assertEquals(
                 expected,
-                DataConverter.bytesToLong(toParse),
+                ArrayConverter.bytesToLong(toParse),
                 "Should convert byte array to correct long value");
 
         // Test with different lengths
         toParse = new byte[] {0x01, 0x02, 0x03};
         expected = 0x010203L;
-        assertEquals(expected, DataConverter.bytesToLong(toParse), "Should work with 3-byte array");
+        assertEquals(
+                expected, ArrayConverter.bytesToLong(toParse), "Should work with 3-byte array");
 
         // Test with single byte
         toParse = new byte[] {(byte) 0xFF};
         expected = 0xFFL;
-        assertEquals(expected, DataConverter.bytesToLong(toParse), "Should work with single byte");
+        assertEquals(expected, ArrayConverter.bytesToLong(toParse), "Should work with single byte");
 
         // Test with empty array
         toParse = new byte[0];
         expected = 0L;
         assertEquals(
-                expected, DataConverter.bytesToLong(toParse), "Should return 0 for empty array");
+                expected, ArrayConverter.bytesToLong(toParse), "Should return 0 for empty array");
 
         // Test with 64-bit MAX_VALUE (all bits set)
         toParse = new byte[8];
@@ -245,32 +246,34 @@ class ArrayConverterTest {
         }
         expected = -1L; // All bits set
         assertEquals(
-                expected, DataConverter.bytesToLong(toParse), "Should handle maximum 64-bit value");
+                expected,
+                ArrayConverter.bytesToLong(toParse),
+                "Should handle maximum 64-bit value");
 
         // Test with array exceeding allowed length (should throw exception)
         final byte[] oversizedLongArray =
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToLong(oversizedLongArray),
+                () -> ArrayConverter.bytesToLong(oversizedLongArray),
                 "Array > 8 bytes should throw IllegalArgumentException");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToLong(null),
+                () -> ArrayConverter.bytesToLong(null),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToHexString method, of class DataConverter. */
+    /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
     void testBytesToHexString_byteArr() {
         byte[] toTest = {0x00, 0x11, 0x22, 0x33, 0x44};
-        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(toTest));
+        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(toTest));
+        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10};
-        assertEquals("00 01 02 03 04 05 06 07 08 09 10", DataConverter.bytesToHexString(toTest));
+        assertEquals("00 01 02 03 04 05 06 07 08 09 10", ArrayConverter.bytesToHexString(toTest));
         toTest =
                 new byte[] {
                     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
@@ -278,7 +281,7 @@ class ArrayConverterTest {
                 };
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(toTest));
+                ArrayConverter.bytesToHexString(toTest));
         toTest =
                 new byte[] {
                     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
@@ -287,22 +290,22 @@ class ArrayConverterTest {
                 };
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(toTest));
+                ArrayConverter.bytesToHexString(toTest));
 
         // Test with null input should throw IllegalArgumentException
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((byte[]) null),
+                () -> ArrayConverter.bytesToHexString((byte[]) null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with empty array
         assertEquals(
                 "",
-                DataConverter.bytesToHexString(new byte[0]),
+                ArrayConverter.bytesToHexString(new byte[0]),
                 "Empty array should return empty string");
     }
 
-    /** Test of bytesToHexString method, of class DataConverter. */
+    /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
     void testBytesToHexString_byteArr_boolean() {
         byte[] toTest = {
@@ -312,19 +315,19 @@ class ArrayConverterTest {
         };
         assertEquals(
                 "00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(toTest, false));
+                ArrayConverter.bytesToHexString(toTest, false));
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(toTest, true));
+                ArrayConverter.bytesToHexString(toTest, true));
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((byte[]) null, false),
+                () -> ArrayConverter.bytesToHexString((byte[]) null, false),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToHexString method, of class DataConverter. */
+    /** Test of bytesToHexString method, of class ArrayConverter. */
     @Test
     void testBytesToHexString_3args() {
         byte[] toTest = {
@@ -335,27 +338,27 @@ class ArrayConverterTest {
         // Test with pretty printing and initialNewLine=true
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(toTest, true, true));
+                ArrayConverter.bytesToHexString(toTest, true, true));
 
         // Test with pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(toTest, true, false));
+                ArrayConverter.bytesToHexString(toTest, true, false));
 
         // Test without pretty printing and initialNewLine=true (initialNewLine should be ignored)
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(toTest, false, true));
+                ArrayConverter.bytesToHexString(toTest, false, true));
 
         // Test without pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(toTest, false, false));
+                ArrayConverter.bytesToHexString(toTest, false, false));
 
         // Test with null array - implementation throws IllegalArgumentException
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((byte[]) null, false, false),
+                () -> ArrayConverter.bytesToHexString((byte[]) null, false, false),
                 "bytesToHexString(null, bool, bool) should throw IllegalArgumentException");
 
         // Test with longer array to check line breaks
@@ -367,16 +370,16 @@ class ArrayConverterTest {
         String expected =
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F\n"
                         + "10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F";
-        assertEquals(expected, DataConverter.bytesToHexString(longArray, true, true));
+        assertEquals(expected, ArrayConverter.bytesToHexString(longArray, true, true));
 
         // Test without initial new line but with pretty printing
         expected =
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F\n"
                         + "10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F";
-        assertEquals(expected, DataConverter.bytesToHexString(longArray, true, false));
+        assertEquals(expected, ArrayConverter.bytesToHexString(longArray, true, false));
     }
 
-    /** Test DataConverter.bytesToRawHexString(). */
+    /** Test ArrayConverter.bytesToRawHexString(). */
     @Test
     void testBytesToRawHexString() {
         byte[] toTest = {
@@ -386,22 +389,22 @@ class ArrayConverterTest {
         };
         assertEquals(
                 "0001020304050607000102030405060700010203040506070001020304050607",
-                DataConverter.bytesToRawHexString(toTest));
+                ArrayConverter.bytesToRawHexString(toTest));
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToRawHexString(null),
+                () -> ArrayConverter.bytesToRawHexString(null),
                 "bytesToRawHexString(null) should throw IllegalArgumentException");
 
         // Test with empty array
         assertEquals(
                 "",
-                DataConverter.bytesToRawHexString(new byte[0]),
+                ArrayConverter.bytesToRawHexString(new byte[0]),
                 "Empty array should return empty string");
     }
 
-    /** Test of concatenate method, of class DataConverter. */
+    /** Test of concatenate method, of class ArrayConverter. */
     @Test
     void testConcatenate_GenericType() {
         String[] array1 = {"a", "b", "c"};
@@ -409,7 +412,7 @@ class ArrayConverterTest {
         String[] array3 = {"g", "h"};
 
         // Test concatenation of two arrays
-        String[] result = DataConverter.concatenate(array1, array2);
+        String[] result = ArrayConverter.concatenate(array1, array2);
         assertEquals(6, result.length, "Should have length 6");
         assertArrayEquals(
                 new String[] {"a", "b", "c", "d", "e", "f"},
@@ -417,7 +420,7 @@ class ArrayConverterTest {
                 "Arrays should be concatenated in order");
 
         // Test concatenation of three arrays
-        result = DataConverter.concatenate(array1, array2, array3);
+        result = ArrayConverter.concatenate(array1, array2, array3);
         assertEquals(8, result.length, "Should have length 8");
         assertArrayEquals(
                 new String[] {"a", "b", "c", "d", "e", "f", "g", "h"},
@@ -427,27 +430,27 @@ class ArrayConverterTest {
         // Test with null array in the middle (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(array1, null, array3),
+                () -> ArrayConverter.concatenate(array1, null, array3),
                 "Null array should throw IllegalArgumentException");
 
         // Test with single array
-        result = DataConverter.concatenate(array1);
+        result = ArrayConverter.concatenate(array1);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(array1, result, "Single array should be unchanged");
 
         // Test with empty arrays
         String[] emptyArray = new String[0];
-        result = DataConverter.concatenate(emptyArray, emptyArray);
+        result = ArrayConverter.concatenate(emptyArray, emptyArray);
         assertEquals(0, result.length, "Should have length 0 for empty arrays");
 
         // Test with null parameter (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate((String[][]) null),
+                () -> ArrayConverter.concatenate((String[][]) null),
                 "Should throw IllegalArgumentException for null parameter");
     }
 
-    /** Test of concatenate method, of class DataConverter. */
+    /** Test of concatenate method, of class ArrayConverter. */
     @Test
     void testConcatenate_byteArrArr() {
         byte[] array1 = {0x01, 0x02, 0x03};
@@ -455,7 +458,7 @@ class ArrayConverterTest {
         byte[] array3 = {0x07, 0x08};
 
         // Test concatenation of two arrays
-        byte[] result = DataConverter.concatenate(array1, array2);
+        byte[] result = ArrayConverter.concatenate(array1, array2);
         assertEquals(6, result.length, "Should have length 6");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
@@ -463,7 +466,7 @@ class ArrayConverterTest {
                 "Arrays should be concatenated in order");
 
         // Test concatenation of three arrays
-        result = DataConverter.concatenate(array1, array2, array3);
+        result = ArrayConverter.concatenate(array1, array2, array3);
         assertEquals(8, result.length, "Should have length 8");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
@@ -473,21 +476,21 @@ class ArrayConverterTest {
         // Test with null array in the middle (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(array1, null, array3),
+                () -> ArrayConverter.concatenate(array1, null, array3),
                 "Null array should throw IllegalArgumentException");
 
         // Test with single array
-        result = DataConverter.concatenate(array1);
+        result = ArrayConverter.concatenate(array1);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(array1, result, "Single array should be unchanged");
 
         // Test with empty arrays
         byte[] emptyArray = new byte[0];
-        result = DataConverter.concatenate(emptyArray, emptyArray);
+        result = ArrayConverter.concatenate(emptyArray, emptyArray);
         assertEquals(0, result.length, "Should have length 0 for empty arrays");
 
         // Test with zero-length array
-        result = DataConverter.concatenate(array1, new byte[0]);
+        result = ArrayConverter.concatenate(array1, new byte[0]);
         assertEquals(
                 3,
                 result.length,
@@ -497,17 +500,17 @@ class ArrayConverterTest {
         // Test with null parameter (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate((byte[][]) null),
+                () -> ArrayConverter.concatenate((byte[][]) null),
                 "Should throw IllegalArgumentException for null parameter");
 
         // Test with illegal argument
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(new byte[0][0]),
+                () -> ArrayConverter.concatenate(new byte[0][0]),
                 "Should throw IllegalArgumentException for empty parameter list");
 
         // Test limited concatenation with the 3-parameter method
-        result = DataConverter.concatenate(array1, array2, 2);
+        result = ArrayConverter.concatenate(array1, array2, 2);
         assertEquals(5, result.length, "Should have length 5");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05},
@@ -515,7 +518,7 @@ class ArrayConverterTest {
                 "Should only use 2 bytes from second array");
 
         // Test with zero bytes from second array
-        result = DataConverter.concatenate(array1, array2, 0);
+        result = ArrayConverter.concatenate(array1, array2, 0);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(
                 array1, result, "Should only use first array when second byte count is 0");
@@ -523,43 +526,43 @@ class ArrayConverterTest {
         // Test with null first array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(null, array2, 1),
+                () -> ArrayConverter.concatenate(null, array2, 1),
                 "First array null should throw IllegalArgumentException");
 
         // Test with null second array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(array1, null, 1),
+                () -> ArrayConverter.concatenate(array1, null, 1),
                 "Second array null should throw IllegalArgumentException");
 
         // Test with invalid number of bytes (negative)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(array1, array2, -1),
+                () -> ArrayConverter.concatenate(array1, array2, -1),
                 "Negative bytes should throw IllegalArgumentException");
 
         // Test with invalid number of bytes (greater than array2.length)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.concatenate(array1, array2, array2.length + 1),
+                () -> ArrayConverter.concatenate(array1, array2, array2.length + 1),
                 "Too many bytes should throw IllegalArgumentException");
     }
 
-    /** Test of makeArrayNonZero method, of class DataConverter. */
+    /** Test of makeArrayNonZero method, of class ArrayConverter. */
     @Test
     void testMakeArrayNonZero() {
         // Test with array containing zeros
         byte[] testArray = {0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00};
         byte[] expectedArray = {0x01, 0x01, 0x01, 0x02, 0x01, 0x03, 0x01};
 
-        DataConverter.makeArrayNonZero(testArray);
+        ArrayConverter.makeArrayNonZero(testArray);
         assertArrayEquals(expectedArray, testArray, "All zero bytes should be replaced with 0x01");
 
         // Test with array containing no zeros
         testArray = new byte[] {0x01, 0x02, 0x03, 0x04};
         byte[] originalArray = testArray.clone();
 
-        DataConverter.makeArrayNonZero(testArray);
+        ArrayConverter.makeArrayNonZero(testArray);
         assertArrayEquals(originalArray, testArray, "Array without zeros should remain unchanged");
 
         // Test with all zeros
@@ -569,51 +572,51 @@ class ArrayConverterTest {
             expectedArray[i] = 0x01;
         }
 
-        DataConverter.makeArrayNonZero(testArray);
+        ArrayConverter.makeArrayNonZero(testArray);
         assertArrayEquals(
                 expectedArray, testArray, "All-zero array should be completely replaced with 0x01");
 
         // Test with empty array
         testArray = new byte[0];
-        DataConverter.makeArrayNonZero(testArray);
+        ArrayConverter.makeArrayNonZero(testArray);
         assertEquals(0, testArray.length, "Empty array should remain empty");
 
         // Test with null array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.makeArrayNonZero(null),
+                () -> ArrayConverter.makeArrayNonZero(null),
                 "Null array should throw IllegalArgumentException");
     }
 
-    /** Test of bigIntegerToByteArray method, of class DataConverter. */
+    /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
     @Test
     void testBigIntegerToByteArray_3args() {
         // Test with expected length and remove sign byte
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
 
         // Test with expected length = 8 and remove sign byte = true
-        byte[] result = DataConverter.bigIntegerToByteArray(testValue, 8, true);
+        byte[] result = ArrayConverter.bigIntegerToByteArray(testValue, 8, true);
         assertEquals(8, result.length, "Should have length 8");
         // Only verify the length, not the exact content as the padding behavior seems different
         // than what we expected
 
         // Test with expected length = 4 and remove sign byte = true (truncated)
-        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(8, result.length, "Should have length 8 since BigInteger is larger");
 
         // Test with zero value
         testValue = BigInteger.ZERO;
-        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(4, result.length, "Zero should have expected length");
         assertArrayEquals(new byte[4], result, "Zero should be all zeros");
 
         // Test with zero expected length
-        result = DataConverter.bigIntegerToByteArray(testValue, 0, true);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 0, true);
         assertEquals(0, result.length, "With expected length 0, should return empty array");
 
         // Test with negative value (should have sign byte)
         testValue = new BigInteger("-ABCDEF", 16);
-        result = DataConverter.bigIntegerToByteArray(testValue, 4, false);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, false);
         assertEquals(4, result.length, "Should respect expected length");
 
         // Test with sign byte that should be preserved
@@ -621,26 +624,26 @@ class ArrayConverterTest {
         byte[] rawBytes = testValue.toByteArray(); // Should be: [00, 80, AB, CD, EF]
         assertTrue(rawBytes[0] == 0x00, "Should have sign byte");
 
-        result = DataConverter.bigIntegerToByteArray(testValue, 4, false);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, false);
         assertEquals(8, result.length, "Should have padding to be multiple of expected length");
 
-        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(4, result.length, "Should remove sign byte and match expected length");
 
         // Test with null value
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bigIntegerToByteArray(null, 4, true),
+                () -> ArrayConverter.bigIntegerToByteArray(null, 4, true),
                 "Null BigInteger should throw IllegalArgumentException");
     }
 
-    /** Test of bigIntegerToByteArray method, of class DataConverter. */
+    /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
     @Test
     void testBigIntegerToByteArray_BigInteger() {
         // Test with simple positive value
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
-        byte[] expected = DataConverter.hexStringToByteArray("ABCDEF1234567890");
-        byte[] result = DataConverter.bigIntegerToByteArray(testValue);
+        byte[] expected = ArrayConverter.hexStringToByteArray("ABCDEF1234567890");
+        byte[] result = ArrayConverter.bigIntegerToByteArray(testValue);
         assertArrayEquals(expected, result, "Should convert simple BigInteger correctly");
 
         // Test with value that has high bit set (would have sign byte)
@@ -648,23 +651,23 @@ class ArrayConverterTest {
         byte[] rawBytes = testValue.toByteArray(); // Should be: [00, 80, AB, CD, EF]
         assertTrue(rawBytes[0] == 0x00, "Should have sign byte in raw conversion");
 
-        expected = DataConverter.hexStringToByteArray("80ABCDEF");
-        result = DataConverter.bigIntegerToByteArray(testValue);
+        expected = ArrayConverter.hexStringToByteArray("80ABCDEF");
+        result = ArrayConverter.bigIntegerToByteArray(testValue);
         assertArrayEquals(expected, result, "Should remove sign byte");
 
         // Test with zero
         testValue = BigInteger.ZERO;
-        result = DataConverter.bigIntegerToByteArray(testValue);
+        result = ArrayConverter.bigIntegerToByteArray(testValue);
         assertTrue(result.length == 0, "Zero should be represented as either an empty array");
 
         // Test with null value
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bigIntegerToByteArray(null),
+                () -> ArrayConverter.bigIntegerToByteArray(null),
                 "Null BigInteger should throw IllegalArgumentException");
     }
 
-    /** Test of convertListToArray method, of class DataConverter. */
+    /** Test of convertListToArray method, of class ArrayConverter. */
     @Test
     void testConvertListToArray() {
         List<BigInteger> testList = new ArrayList<>();
@@ -673,7 +676,7 @@ class ArrayConverterTest {
         testList.add(BigInteger.valueOf(3));
         testList.add(BigInteger.valueOf(Integer.MAX_VALUE));
 
-        BigInteger[] result = DataConverter.convertListToArray(testList);
+        BigInteger[] result = ArrayConverter.convertListToArray(testList);
 
         assertEquals(4, result.length, "Array length should match list size");
         assertEquals(BigInteger.valueOf(1), result[0], "First element should match");
@@ -684,14 +687,14 @@ class ArrayConverterTest {
 
         // Test with empty list
         testList = new ArrayList<>();
-        result = DataConverter.convertListToArray(testList);
+        result = ArrayConverter.convertListToArray(testList);
         assertEquals(0, result.length, "Empty list should convert to empty array");
 
         // Test with large values
         testList = new ArrayList<>();
         testList.add(new BigInteger("FFFFFFFFFFFFFFFF", 16));
         testList.add(new BigInteger("7FFFFFFFFFFFFFFF", 16));
-        result = DataConverter.convertListToArray(testList);
+        result = ArrayConverter.convertListToArray(testList);
         assertEquals(2, result.length, "Should handle large BigInteger values");
         assertEquals(
                 new BigInteger("FFFFFFFFFFFFFFFF", 16),
@@ -705,39 +708,39 @@ class ArrayConverterTest {
         // Test with null list
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.convertListToArray(null),
+                () -> ArrayConverter.convertListToArray(null),
                 "Null list should throw IllegalArgumentException");
     }
 
-    /** Test of hexStringToByteArray method, of class DataConverter. */
+    /** Test of hexStringToByteArray method, of class ArrayConverter. */
     @Test
     void testHexStringToByteArray() {
         String hex = "01";
         assertArrayEquals(
                 new byte[] {0x01},
-                DataConverter.hexStringToByteArray(hex),
+                ArrayConverter.hexStringToByteArray(hex),
                 "Testing simple one byte hex value");
         hex = "FF";
         assertArrayEquals(
                 new byte[] {(byte) 0xff},
-                DataConverter.hexStringToByteArray(hex),
+                ArrayConverter.hexStringToByteArray(hex),
                 "Testing one byte hex value > 0x7f");
         hex = "FFFFFF";
         assertArrayEquals(
                 new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff},
-                DataConverter.hexStringToByteArray(hex),
+                ArrayConverter.hexStringToByteArray(hex),
                 "Testing one byte hex value > 0x7f");
 
         // Test with null input (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.hexStringToByteArray(null),
+                () -> ArrayConverter.hexStringToByteArray(null),
                 "Should throw IllegalArgumentException for null input");
 
         // Test with odd length string (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.hexStringToByteArray("ABC"),
+                () -> ArrayConverter.hexStringToByteArray("ABC"),
                 "Should throw IllegalArgumentException for odd-length string");
     }
 
@@ -747,45 +750,45 @@ class ArrayConverterTest {
 
         assertArrayEquals(
                 new byte[0],
-                DataConverter.bigIntegerToNullPaddedByteArray(test, 0),
+                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 0),
                 "Check zero output size");
         assertArrayEquals(
                 new byte[] {(byte) 0xEC},
-                DataConverter.bigIntegerToNullPaddedByteArray(test, 1),
+                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 1),
                 "Check check output size smaller than input");
         assertArrayEquals(
-                DataConverter.hexStringToByteArray("0000000000000000000000001D42C86F7923DFEC"),
-                DataConverter.bigIntegerToNullPaddedByteArray(test, 20),
+                ArrayConverter.hexStringToByteArray("0000000000000000000000001D42C86F7923DFEC"),
+                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 20),
                 "Check output size bigger than input size");
 
         // Test with null input (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bigIntegerToNullPaddedByteArray(null, 8),
+                () -> ArrayConverter.bigIntegerToNullPaddedByteArray(null, 8),
                 "Should throw IllegalArgumentException for null input");
     }
 
     @Test
     void testLongToUint48Bytes() {
         long testValue = 0x0000123456789ABCL;
-        byte[] expectedResult = DataConverter.hexStringToByteArray("123456789ABC");
+        byte[] expectedResult = ArrayConverter.hexStringToByteArray("123456789ABC");
 
         assertArrayEquals(
                 expectedResult,
-                DataConverter.longToUint48Bytes(testValue),
+                ArrayConverter.longToUint48Bytes(testValue),
                 "Assert correct output");
 
         testValue = 0x0000000000000001L;
-        expectedResult = DataConverter.hexStringToByteArray("000000000001");
+        expectedResult = ArrayConverter.hexStringToByteArray("000000000001");
 
         assertArrayEquals(
                 expectedResult,
-                DataConverter.longToUint48Bytes(testValue),
+                ArrayConverter.longToUint48Bytes(testValue),
                 "Assert correct output");
     }
 
     /**
-     * Test of bytesToHexString method, of class DataConverter. Differences in the overloaded
+     * Test of bytesToHexString method, of class ArrayConverter. Differences in the overloaded
      * methods should be visible in the other tests since the methods just pass the .getValue().
      */
     @Test
@@ -795,13 +798,13 @@ class ArrayConverterTest {
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x11, 0x22, 0x33, 0x44});
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
-        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(mba));
+        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(mba));
+        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -810,7 +813,7 @@ class ArrayConverterTest {
                             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10
                         });
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08 09 10", DataConverter.bytesToHexString(mba));
+        assertEquals("00 01 02 03 04 05 06 07 08 09 10", ArrayConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -822,7 +825,7 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(mba));
+                ArrayConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -835,12 +838,12 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(mba));
+                ArrayConverter.bytesToHexString(mba));
     }
 
     /**
      * Test of bytesToHexString method with three parameters for ModifiableByteArray, of class
-     * DataConverter.
+     * ArrayConverter.
      */
     @Test
     void testBytesToHexString_ModifiableByteArray_3args() {
@@ -857,22 +860,22 @@ class ArrayConverterTest {
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, true, true));
+                ArrayConverter.bytesToHexString(mba, true, true));
 
         // Test with pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, true, false));
+                ArrayConverter.bytesToHexString(mba, true, false));
 
         // Test without pretty printing and initialNewLine=true (should be ignored)
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, false, true));
+                ArrayConverter.bytesToHexString(mba, false, true));
 
         // Test without pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, false, false));
+                ArrayConverter.bytesToHexString(mba, false, false));
 
         // Test with longer array
         toTest =
@@ -890,23 +893,23 @@ class ArrayConverterTest {
         // Test with pretty printing and initialNewLine=true for longer array
         String expected =
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07";
-        assertEquals(expected, DataConverter.bytesToHexString(mba, true, true));
+        assertEquals(expected, ArrayConverter.bytesToHexString(mba, true, true));
 
         // Test with pretty printing and initialNewLine=false for longer array
         expected =
                 "00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07";
-        assertEquals(expected, DataConverter.bytesToHexString(mba, true, false));
+        assertEquals(expected, ArrayConverter.bytesToHexString(mba, true, false));
 
         // Test with null ModifiableByteArray
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((ModifiableByteArray) null, true, true),
+                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null, true, true),
                 "Null ModifiableByteArray should throw IllegalArgumentException");
     }
 
     /**
      * Test of bytesToHexString method with two parameters for ModifiableByteArray, of class
-     * DataConverter.
+     * ArrayConverter.
      */
     @Test
     void testBytesToHexString_ModifiableByteArray_boolean() {
@@ -917,14 +920,14 @@ class ArrayConverterTest {
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x11, 0x22, 0x33, 0x44});
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
-        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(mba, false));
+        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(mba, false));
 
         // Test a medium array (9 bytes) with pretty printing disabled
         toTest =
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(mba, false));
+        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(mba, false));
 
         // Test a 16-byte array with pretty printing enabled
         toTest =
@@ -937,12 +940,12 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, true));
+                ArrayConverter.bytesToHexString(mba, true));
 
         // Test a 16-byte array with pretty printing disabled
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                DataConverter.bytesToHexString(mba, false));
+                ArrayConverter.bytesToHexString(mba, false));
 
         // Test a larger array (32 bytes) with pretty printing enabled
         toTest =
@@ -956,17 +959,17 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(mba, true));
+                ArrayConverter.bytesToHexString(mba, true));
 
         // Test a larger array with pretty printing disabled
         assertEquals(
                 "00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07",
-                DataConverter.bytesToHexString(mba, false));
+                ArrayConverter.bytesToHexString(mba, false));
 
         // Test with null ModifiableByteArray
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString((ModifiableByteArray) null, false),
+                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null, false),
                 "Null ModifiableByteArray should throw IllegalArgumentException");
     }
 
@@ -978,42 +981,42 @@ class ArrayConverterTest {
         // Test for the single argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString(mba),
+                () -> ArrayConverter.bytesToHexString(mba),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
 
         // Test for the two argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString(mba, true),
+                () -> ArrayConverter.bytesToHexString(mba, true),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
 
         // Test for the three argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.bytesToHexString(mba, true, true),
+                () -> ArrayConverter.bytesToHexString(mba, true, true),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
     }
 
-    /** Test of reverseByteOrder method, of class DataConverter. */
+    /** Test of reverseByteOrder method, of class ArrayConverter. */
     @Test
     void testReverseByteOrder() {
         byte[] array = {0x00, 0x01, 0x02, 0x03, 0x04};
 
         assertArrayEquals(
                 new byte[] {0x04, 0x03, 0x02, 0x01, 0x00},
-                DataConverter.reverseByteOrder(array),
+                ArrayConverter.reverseByteOrder(array),
                 "Testing byte order reversion");
 
         // Test with null array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.reverseByteOrder(null),
+                () -> ArrayConverter.reverseByteOrder(null),
                 "Null array should throw IllegalArgumentException");
 
         // Test with empty array
         assertArrayEquals(
                 new byte[0],
-                DataConverter.reverseByteOrder(new byte[0]),
+                ArrayConverter.reverseByteOrder(new byte[0]),
                 "Empty array should be reversed to empty array");
     }
 
@@ -1022,7 +1025,7 @@ class ArrayConverterTest {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             BigInteger b = new BigInteger(1024 + r.nextInt(1000), r);
-            byte[] bigIntegerToByteArray = DataConverter.bigIntegerToByteArray(b);
+            byte[] bigIntegerToByteArray = ArrayConverter.bigIntegerToByteArray(b);
             BigInteger c = new BigInteger(1, bigIntegerToByteArray);
             assertEquals(b, c);
         }
@@ -1031,7 +1034,7 @@ class ArrayConverterTest {
     @Test
     void testBigIntegerToByteArrayWithZero() {
         // Test with BigInteger.ZERO
-        byte[] result = DataConverter.bigIntegerToByteArray(BigInteger.ZERO);
+        byte[] result = ArrayConverter.bigIntegerToByteArray(BigInteger.ZERO);
         assertArrayEquals(new byte[0], result, "BigInteger.ZERO should convert to new byte[0]");
     }
 
@@ -1040,29 +1043,29 @@ class ArrayConverterTest {
         // Test with positive byte values (0-127)
         assertEquals(
                 0,
-                DataConverter.byteToUnsignedInt((byte) 0x00),
+                ArrayConverter.byteToUnsignedInt((byte) 0x00),
                 "0x00 should convert to unsigned int 0");
         assertEquals(
                 1,
-                DataConverter.byteToUnsignedInt((byte) 0x01),
+                ArrayConverter.byteToUnsignedInt((byte) 0x01),
                 "0x01 should convert to unsigned int 1");
         assertEquals(
                 127,
-                DataConverter.byteToUnsignedInt((byte) 0x7F),
+                ArrayConverter.byteToUnsignedInt((byte) 0x7F),
                 "0x7F should convert to unsigned int 127");
 
         // Test with negative byte values (which are unsigned 128-255)
         assertEquals(
                 128,
-                DataConverter.byteToUnsignedInt((byte) 0x80),
+                ArrayConverter.byteToUnsignedInt((byte) 0x80),
                 "0x80 should convert to unsigned int 128");
         assertEquals(
                 255,
-                DataConverter.byteToUnsignedInt((byte) 0xFF),
+                ArrayConverter.byteToUnsignedInt((byte) 0xFF),
                 "0xFF should convert to unsigned int 255");
         assertEquals(
                 200,
-                DataConverter.byteToUnsignedInt((byte) 0xC8),
+                ArrayConverter.byteToUnsignedInt((byte) 0xC8),
                 "0xC8 should convert to unsigned int 200");
     }
 
@@ -1075,7 +1078,7 @@ class ArrayConverterTest {
         long expected = 0x0123456789ABCDEFL;
         assertEquals(
                 expected,
-                DataConverter.uInt64BytesToLong(testBytes),
+                ArrayConverter.uInt64BytesToLong(testBytes),
                 "Should convert 8 bytes to correct long value");
 
         // Test with all zeros
@@ -1083,7 +1086,7 @@ class ArrayConverterTest {
         expected = 0L;
         assertEquals(
                 expected,
-                DataConverter.uInt64BytesToLong(testBytes),
+                ArrayConverter.uInt64BytesToLong(testBytes),
                 "All zeros should convert to 0L");
 
         // Test with all ones (FF)
@@ -1094,20 +1097,20 @@ class ArrayConverterTest {
         expected = -1L; // All bits set in a long
         assertEquals(
                 expected,
-                DataConverter.uInt64BytesToLong(testBytes),
+                ArrayConverter.uInt64BytesToLong(testBytes),
                 "All FFs should convert to -1L (all bits set)");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.uInt64BytesToLong(null),
+                () -> ArrayConverter.uInt64BytesToLong(null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with wrong length
         final byte[] wrongLengthArray = new byte[7]; // Not 8 bytes
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.uInt64BytesToLong(wrongLengthArray),
+                () -> ArrayConverter.uInt64BytesToLong(wrongLengthArray),
                 "Array != 8 bytes should throw IllegalArgumentException");
     }
 
@@ -1118,7 +1121,7 @@ class ArrayConverterTest {
         long expected = 0x89ABCDEFL;
         assertEquals(
                 expected,
-                DataConverter.uInt32BytesToLong(testBytes),
+                ArrayConverter.uInt32BytesToLong(testBytes),
                 "Should convert 4 bytes to correct long value");
 
         // Test with all zeros
@@ -1126,7 +1129,7 @@ class ArrayConverterTest {
         expected = 0L;
         assertEquals(
                 expected,
-                DataConverter.uInt32BytesToLong(testBytes),
+                ArrayConverter.uInt32BytesToLong(testBytes),
                 "All zeros should convert to 0L");
 
         // Test with all ones (FF)
@@ -1137,7 +1140,7 @@ class ArrayConverterTest {
         expected = 0xFFFFFFFFL; // 32 bits set
         assertEquals(
                 expected,
-                DataConverter.uInt32BytesToLong(testBytes),
+                ArrayConverter.uInt32BytesToLong(testBytes),
                 "All FFs should convert to 0xFFFFFFFFL");
 
         // Test with high bit set (would be negative in a 32-bit int)
@@ -1145,20 +1148,20 @@ class ArrayConverterTest {
         expected = 0x80000000L;
         assertEquals(
                 expected,
-                DataConverter.uInt32BytesToLong(testBytes),
+                ArrayConverter.uInt32BytesToLong(testBytes),
                 "High bit should be preserved as unsigned");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.uInt32BytesToLong(null),
+                () -> ArrayConverter.uInt32BytesToLong(null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with wrong length
         final byte[] wrongLengthArray = new byte[3]; // Not 4 bytes
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.uInt32BytesToLong(wrongLengthArray),
+                () -> ArrayConverter.uInt32BytesToLong(wrongLengthArray),
                 "Array != 4 bytes should throw IllegalArgumentException");
     }
 
@@ -1167,48 +1170,48 @@ class ArrayConverterTest {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             Integer b = r.nextInt();
-            byte[] intBytes = DataConverter.intToBytes(b, 4);
-            Integer c = DataConverter.bytesToInt(intBytes);
+            byte[] intBytes = ArrayConverter.intToBytes(b, 4);
+            Integer c = ArrayConverter.bytesToInt(intBytes);
             assertEquals(b, c);
         }
     }
 
-    /** Test of indexOf method, of class DataConverter. */
+    /** Test of indexOf method, of class ArrayConverter. */
     @Test
     void testIndexOf() {
-        byte[] outerArray = DataConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
-        byte[] innerArray1 = DataConverter.hexStringToByteArray("BBCCDD");
-        byte[] innerArray2 = DataConverter.hexStringToByteArray("BBCCDDEE");
-        byte[] innerArray3 = DataConverter.hexStringToByteArray("FF");
+        byte[] outerArray = ArrayConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
+        byte[] innerArray1 = ArrayConverter.hexStringToByteArray("BBCCDD");
+        byte[] innerArray2 = ArrayConverter.hexStringToByteArray("BBCCDDEE");
+        byte[] innerArray3 = ArrayConverter.hexStringToByteArray("FF");
         byte[] emptyArray = new byte[0];
 
-        assertEquals(1, DataConverter.indexOf(outerArray, innerArray1));
-        assertNull(DataConverter.indexOf(outerArray, innerArray2));
-        assertNull(DataConverter.indexOf(outerArray, innerArray3));
+        assertEquals(1, ArrayConverter.indexOf(outerArray, innerArray1));
+        assertNull(ArrayConverter.indexOf(outerArray, innerArray2));
+        assertNull(ArrayConverter.indexOf(outerArray, innerArray3));
 
         // Test with null outer array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.indexOf(null, innerArray1),
+                () -> ArrayConverter.indexOf(null, innerArray1),
                 "Null outer array should throw IllegalArgumentException");
 
         // Test with null inner array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.indexOf(outerArray, null),
+                () -> ArrayConverter.indexOf(outerArray, null),
                 "Null inner array should throw IllegalArgumentException");
 
         // Test with empty inner array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> DataConverter.indexOf(outerArray, emptyArray),
+                () -> ArrayConverter.indexOf(outerArray, emptyArray),
                 "Empty inner array should throw IllegalArgumentException");
 
         // Test with inner array longer than outer array
         byte[] smallOuterArray = new byte[3];
         byte[] largeInnerArray = new byte[4];
         assertNull(
-                DataConverter.indexOf(smallOuterArray, largeInnerArray),
+                ArrayConverter.indexOf(smallOuterArray, largeInnerArray),
                 "Inner array should not be found when longer than outer array");
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ArrayConverterTest.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.api.Test;
 
 class ArrayConverterTest {
 
-    /** Test of longToUint64Bytes method, of class ArrayConverter. */
+    /** Test of longToUint64Bytes method, of class DataConverter. */
     @Test
     void testLongToUint64Bytes() {
         long testValue = 0x0123456789ABCDEFL;
-        byte[] result = ArrayConverter.longToUint64Bytes(testValue);
+        byte[] result = DataConverter.longToUint64Bytes(testValue);
         byte[] expected = {
             0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
         };
@@ -36,13 +36,13 @@ class ArrayConverterTest {
 
         // Test with zero value
         testValue = 0L;
-        result = ArrayConverter.longToUint64Bytes(testValue);
+        result = DataConverter.longToUint64Bytes(testValue);
         expected = new byte[8]; // All zeros
         assertArrayEquals(expected, result, "The byte array should be all zeros");
 
         // Test with max value
         testValue = -1L; // All bits set to 1 in two's complement (0xFFFFFFFFFFFFFFFF)
-        result = ArrayConverter.longToUint64Bytes(testValue);
+        result = DataConverter.longToUint64Bytes(testValue);
         expected = new byte[8];
         for (int i = 0; i < expected.length; i++) {
             expected[i] = (byte) 0xFF;
@@ -50,24 +50,24 @@ class ArrayConverterTest {
         assertArrayEquals(expected, result, "The byte array should be all FF");
     }
 
-    /** Test of longToUint32Bytes method, of class ArrayConverter. */
+    /** Test of longToUint32Bytes method, of class DataConverter. */
     @Test
     void testLongToUint32Bytes() {
         long testValue = 0x89ABCDEFL;
-        byte[] result = ArrayConverter.longToUint32Bytes(testValue);
+        byte[] result = DataConverter.longToUint32Bytes(testValue);
         byte[] expected = {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
 
         assertArrayEquals(expected, result, "The byte array should match the expected 4-bytes");
 
         // Test with zero value
         testValue = 0L;
-        result = ArrayConverter.longToUint32Bytes(testValue);
+        result = DataConverter.longToUint32Bytes(testValue);
         expected = new byte[4]; // All zeros
         assertArrayEquals(expected, result, "The byte array should be all zeros");
 
         // Test with max 32-bit value
         testValue = 0xFFFFFFFFL;
-        result = ArrayConverter.longToUint32Bytes(testValue);
+        result = DataConverter.longToUint32Bytes(testValue);
         expected = new byte[4];
         for (int i = 0; i < expected.length; i++) {
             expected[i] = (byte) 0xFF;
@@ -76,17 +76,17 @@ class ArrayConverterTest {
 
         // Test with value greater than 32 bits (should truncate high bits)
         testValue = 0x0123456789ABCDEFL;
-        result = ArrayConverter.longToUint32Bytes(testValue);
+        result = DataConverter.longToUint32Bytes(testValue);
         expected = new byte[] {(byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
         assertArrayEquals(
                 expected, result, "The byte array should only contain the lowest 32 bits");
     }
 
-    /** Test of intToBytes method, of class ArrayConverter. */
+    /** Test of intToBytes method, of class DataConverter. */
     @Test
     void testIntToBytes() {
         int toParse = 5717;
-        byte[] result = ArrayConverter.intToBytes(toParse, 2);
+        byte[] result = DataConverter.intToBytes(toParse, 2);
         assertArrayEquals(
                 new byte[] {0x16, 0x55},
                 result,
@@ -95,31 +95,31 @@ class ArrayConverterTest {
         // Test with invalid size parameter (less than 1)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.intToBytes(42, 0),
+                () -> DataConverter.intToBytes(42, 0),
                 "Should throw IllegalArgumentException for size 0");
 
         // Test with negative size
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.intToBytes(42, -1),
+                () -> DataConverter.intToBytes(42, -1),
                 "Should throw IllegalArgumentException for negative size");
     }
 
     @Test
     void testIntToBytesOverflow() {
         int toParse = 5717;
-        byte[] result = ArrayConverter.intToBytes(toParse, 5);
+        byte[] result = DataConverter.intToBytes(toParse, 5);
         assertArrayEquals(
                 new byte[] {0x00, 0x00, 0x00, 0x16, 0x55},
                 result,
                 "The conversion result of 5717 should be {0x00} {0x00} {0x00} {0x16} {0x55}");
     }
 
-    /** Test of intToBytes method, of class ArrayConverter. */
+    /** Test of intToBytes method, of class DataConverter. */
     @Test
     void testLongToBytes() {
         long toParse = 5717;
-        byte[] result = ArrayConverter.longToBytes(toParse, 2);
+        byte[] result = DataConverter.longToBytes(toParse, 2);
         assertArrayEquals(
                 new byte[] {0x16, 0x55},
                 result,
@@ -129,7 +129,7 @@ class ArrayConverterTest {
     @Test
     void testLongToBytesOverflow() {
         int toParse = 5717;
-        byte[] result = ArrayConverter.longToBytes(toParse, 10);
+        byte[] result = DataConverter.longToBytes(toParse, 10);
         assertArrayEquals(
                 new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x55},
                 result,
@@ -144,24 +144,24 @@ class ArrayConverterTest {
         // Test with size 0
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.longToBytes(value, 0),
+                () -> DataConverter.longToBytes(value, 0),
                 "Should throw IllegalArgumentException for size 0");
 
         // Test with negative size
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.longToBytes(value, -1),
+                () -> DataConverter.longToBytes(value, -1),
                 "Should throw IllegalArgumentException for negative size");
     }
 
-    /** Test of bytesToInt method, of class ArrayConverter. */
+    /** Test of bytesToInt method, of class DataConverter. */
     @Test
     void testBytesToInt() {
         byte[] toParse = {0x16, 0x55};
         int expectedResult = 5717;
         assertEquals(
                 expectedResult,
-                ArrayConverter.bytesToInt(toParse),
+                DataConverter.bytesToInt(toParse),
                 "The conversion result of {0x16, 0x55} should be 5717");
 
         // Test with empty array
@@ -169,7 +169,7 @@ class ArrayConverterTest {
         expectedResult = 0;
         assertEquals(
                 expectedResult,
-                ArrayConverter.bytesToInt(toParse),
+                DataConverter.bytesToInt(toParse),
                 "Empty array should convert to 0");
 
         // Test with 4 bytes (max allowed)
@@ -177,20 +177,20 @@ class ArrayConverterTest {
         expectedResult = 0x01020304;
         assertEquals(
                 expectedResult,
-                ArrayConverter.bytesToInt(toParse),
+                DataConverter.bytesToInt(toParse),
                 "4-byte array should convert correctly");
 
         // Test with array exceeding allowed length (should throw exception)
         final byte[] oversizedIntArray = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05};
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToInt(oversizedIntArray),
+                () -> DataConverter.bytesToInt(oversizedIntArray),
                 "Array > 4 bytes should throw IllegalArgumentException");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToInt(null),
+                () -> DataConverter.bytesToInt(null),
                 "Null input should throw IllegalArgumentException");
     }
 
@@ -198,7 +198,7 @@ class ArrayConverterTest {
     void testModifiableVariableToHexString() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null),
+                () -> DataConverter.bytesToHexString((ModifiableByteArray) null),
                 "Null input should throw IllegalArgumentException");
     }
 
@@ -206,11 +206,11 @@ class ArrayConverterTest {
     void testConcatatenateGenericArray() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(new Object[][] {}),
+                () -> DataConverter.concatenate(new Object[][] {}),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToLong method, of class ArrayConverter. */
+    /** Test of bytesToLong method, of class DataConverter. */
     @Test
     void testBytesToLong() {
         byte[] toParse = {
@@ -219,25 +219,24 @@ class ArrayConverterTest {
         long expected = 0x0123456789ABCDEFL;
         assertEquals(
                 expected,
-                ArrayConverter.bytesToLong(toParse),
+                DataConverter.bytesToLong(toParse),
                 "Should convert byte array to correct long value");
 
         // Test with different lengths
         toParse = new byte[] {0x01, 0x02, 0x03};
         expected = 0x010203L;
-        assertEquals(
-                expected, ArrayConverter.bytesToLong(toParse), "Should work with 3-byte array");
+        assertEquals(expected, DataConverter.bytesToLong(toParse), "Should work with 3-byte array");
 
         // Test with single byte
         toParse = new byte[] {(byte) 0xFF};
         expected = 0xFFL;
-        assertEquals(expected, ArrayConverter.bytesToLong(toParse), "Should work with single byte");
+        assertEquals(expected, DataConverter.bytesToLong(toParse), "Should work with single byte");
 
         // Test with empty array
         toParse = new byte[0];
         expected = 0L;
         assertEquals(
-                expected, ArrayConverter.bytesToLong(toParse), "Should return 0 for empty array");
+                expected, DataConverter.bytesToLong(toParse), "Should return 0 for empty array");
 
         // Test with 64-bit MAX_VALUE (all bits set)
         toParse = new byte[8];
@@ -246,34 +245,32 @@ class ArrayConverterTest {
         }
         expected = -1L; // All bits set
         assertEquals(
-                expected,
-                ArrayConverter.bytesToLong(toParse),
-                "Should handle maximum 64-bit value");
+                expected, DataConverter.bytesToLong(toParse), "Should handle maximum 64-bit value");
 
         // Test with array exceeding allowed length (should throw exception)
         final byte[] oversizedLongArray =
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToLong(oversizedLongArray),
+                () -> DataConverter.bytesToLong(oversizedLongArray),
                 "Array > 8 bytes should throw IllegalArgumentException");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToLong(null),
+                () -> DataConverter.bytesToLong(null),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToHexString method, of class ArrayConverter. */
+    /** Test of bytesToHexString method, of class DataConverter. */
     @Test
     void testBytesToHexString_byteArr() {
         byte[] toTest = {0x00, 0x11, 0x22, 0x33, 0x44};
-        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(toTest));
+        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(toTest));
+        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(toTest));
         toTest = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10};
-        assertEquals("00 01 02 03 04 05 06 07 08 09 10", ArrayConverter.bytesToHexString(toTest));
+        assertEquals("00 01 02 03 04 05 06 07 08 09 10", DataConverter.bytesToHexString(toTest));
         toTest =
                 new byte[] {
                     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
@@ -281,7 +278,7 @@ class ArrayConverterTest {
                 };
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(toTest));
+                DataConverter.bytesToHexString(toTest));
         toTest =
                 new byte[] {
                     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04,
@@ -290,22 +287,22 @@ class ArrayConverterTest {
                 };
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(toTest));
+                DataConverter.bytesToHexString(toTest));
 
         // Test with null input should throw IllegalArgumentException
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((byte[]) null),
+                () -> DataConverter.bytesToHexString((byte[]) null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with empty array
         assertEquals(
                 "",
-                ArrayConverter.bytesToHexString(new byte[0]),
+                DataConverter.bytesToHexString(new byte[0]),
                 "Empty array should return empty string");
     }
 
-    /** Test of bytesToHexString method, of class ArrayConverter. */
+    /** Test of bytesToHexString method, of class DataConverter. */
     @Test
     void testBytesToHexString_byteArr_boolean() {
         byte[] toTest = {
@@ -315,19 +312,19 @@ class ArrayConverterTest {
         };
         assertEquals(
                 "00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(toTest, false));
+                DataConverter.bytesToHexString(toTest, false));
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(toTest, true));
+                DataConverter.bytesToHexString(toTest, true));
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((byte[]) null, false),
+                () -> DataConverter.bytesToHexString((byte[]) null, false),
                 "Null input should throw IllegalArgumentException");
     }
 
-    /** Test of bytesToHexString method, of class ArrayConverter. */
+    /** Test of bytesToHexString method, of class DataConverter. */
     @Test
     void testBytesToHexString_3args() {
         byte[] toTest = {
@@ -338,27 +335,27 @@ class ArrayConverterTest {
         // Test with pretty printing and initialNewLine=true
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(toTest, true, true));
+                DataConverter.bytesToHexString(toTest, true, true));
 
         // Test with pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(toTest, true, false));
+                DataConverter.bytesToHexString(toTest, true, false));
 
         // Test without pretty printing and initialNewLine=true (initialNewLine should be ignored)
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(toTest, false, true));
+                DataConverter.bytesToHexString(toTest, false, true));
 
         // Test without pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(toTest, false, false));
+                DataConverter.bytesToHexString(toTest, false, false));
 
         // Test with null array - implementation throws IllegalArgumentException
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((byte[]) null, false, false),
+                () -> DataConverter.bytesToHexString((byte[]) null, false, false),
                 "bytesToHexString(null, bool, bool) should throw IllegalArgumentException");
 
         // Test with longer array to check line breaks
@@ -370,16 +367,16 @@ class ArrayConverterTest {
         String expected =
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F\n"
                         + "10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F";
-        assertEquals(expected, ArrayConverter.bytesToHexString(longArray, true, true));
+        assertEquals(expected, DataConverter.bytesToHexString(longArray, true, true));
 
         // Test without initial new line but with pretty printing
         expected =
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F\n"
                         + "10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F";
-        assertEquals(expected, ArrayConverter.bytesToHexString(longArray, true, false));
+        assertEquals(expected, DataConverter.bytesToHexString(longArray, true, false));
     }
 
-    /** Test ArrayConverter.bytesToRawHexString(). */
+    /** Test DataConverter.bytesToRawHexString(). */
     @Test
     void testBytesToRawHexString() {
         byte[] toTest = {
@@ -389,22 +386,22 @@ class ArrayConverterTest {
         };
         assertEquals(
                 "0001020304050607000102030405060700010203040506070001020304050607",
-                ArrayConverter.bytesToRawHexString(toTest));
+                DataConverter.bytesToRawHexString(toTest));
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToRawHexString(null),
+                () -> DataConverter.bytesToRawHexString(null),
                 "bytesToRawHexString(null) should throw IllegalArgumentException");
 
         // Test with empty array
         assertEquals(
                 "",
-                ArrayConverter.bytesToRawHexString(new byte[0]),
+                DataConverter.bytesToRawHexString(new byte[0]),
                 "Empty array should return empty string");
     }
 
-    /** Test of concatenate method, of class ArrayConverter. */
+    /** Test of concatenate method, of class DataConverter. */
     @Test
     void testConcatenate_GenericType() {
         String[] array1 = {"a", "b", "c"};
@@ -412,7 +409,7 @@ class ArrayConverterTest {
         String[] array3 = {"g", "h"};
 
         // Test concatenation of two arrays
-        String[] result = ArrayConverter.concatenate(array1, array2);
+        String[] result = DataConverter.concatenate(array1, array2);
         assertEquals(6, result.length, "Should have length 6");
         assertArrayEquals(
                 new String[] {"a", "b", "c", "d", "e", "f"},
@@ -420,7 +417,7 @@ class ArrayConverterTest {
                 "Arrays should be concatenated in order");
 
         // Test concatenation of three arrays
-        result = ArrayConverter.concatenate(array1, array2, array3);
+        result = DataConverter.concatenate(array1, array2, array3);
         assertEquals(8, result.length, "Should have length 8");
         assertArrayEquals(
                 new String[] {"a", "b", "c", "d", "e", "f", "g", "h"},
@@ -430,27 +427,27 @@ class ArrayConverterTest {
         // Test with null array in the middle (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(array1, null, array3),
+                () -> DataConverter.concatenate(array1, null, array3),
                 "Null array should throw IllegalArgumentException");
 
         // Test with single array
-        result = ArrayConverter.concatenate(array1);
+        result = DataConverter.concatenate(array1);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(array1, result, "Single array should be unchanged");
 
         // Test with empty arrays
         String[] emptyArray = new String[0];
-        result = ArrayConverter.concatenate(emptyArray, emptyArray);
+        result = DataConverter.concatenate(emptyArray, emptyArray);
         assertEquals(0, result.length, "Should have length 0 for empty arrays");
 
         // Test with null parameter (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate((String[][]) null),
+                () -> DataConverter.concatenate((String[][]) null),
                 "Should throw IllegalArgumentException for null parameter");
     }
 
-    /** Test of concatenate method, of class ArrayConverter. */
+    /** Test of concatenate method, of class DataConverter. */
     @Test
     void testConcatenate_byteArrArr() {
         byte[] array1 = {0x01, 0x02, 0x03};
@@ -458,7 +455,7 @@ class ArrayConverterTest {
         byte[] array3 = {0x07, 0x08};
 
         // Test concatenation of two arrays
-        byte[] result = ArrayConverter.concatenate(array1, array2);
+        byte[] result = DataConverter.concatenate(array1, array2);
         assertEquals(6, result.length, "Should have length 6");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
@@ -466,7 +463,7 @@ class ArrayConverterTest {
                 "Arrays should be concatenated in order");
 
         // Test concatenation of three arrays
-        result = ArrayConverter.concatenate(array1, array2, array3);
+        result = DataConverter.concatenate(array1, array2, array3);
         assertEquals(8, result.length, "Should have length 8");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
@@ -476,21 +473,21 @@ class ArrayConverterTest {
         // Test with null array in the middle (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(array1, null, array3),
+                () -> DataConverter.concatenate(array1, null, array3),
                 "Null array should throw IllegalArgumentException");
 
         // Test with single array
-        result = ArrayConverter.concatenate(array1);
+        result = DataConverter.concatenate(array1);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(array1, result, "Single array should be unchanged");
 
         // Test with empty arrays
         byte[] emptyArray = new byte[0];
-        result = ArrayConverter.concatenate(emptyArray, emptyArray);
+        result = DataConverter.concatenate(emptyArray, emptyArray);
         assertEquals(0, result.length, "Should have length 0 for empty arrays");
 
         // Test with zero-length array
-        result = ArrayConverter.concatenate(array1, new byte[0]);
+        result = DataConverter.concatenate(array1, new byte[0]);
         assertEquals(
                 3,
                 result.length,
@@ -500,17 +497,17 @@ class ArrayConverterTest {
         // Test with null parameter (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate((byte[][]) null),
+                () -> DataConverter.concatenate((byte[][]) null),
                 "Should throw IllegalArgumentException for null parameter");
 
         // Test with illegal argument
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(new byte[0][0]),
+                () -> DataConverter.concatenate(new byte[0][0]),
                 "Should throw IllegalArgumentException for empty parameter list");
 
         // Test limited concatenation with the 3-parameter method
-        result = ArrayConverter.concatenate(array1, array2, 2);
+        result = DataConverter.concatenate(array1, array2, 2);
         assertEquals(5, result.length, "Should have length 5");
         assertArrayEquals(
                 new byte[] {0x01, 0x02, 0x03, 0x04, 0x05},
@@ -518,7 +515,7 @@ class ArrayConverterTest {
                 "Should only use 2 bytes from second array");
 
         // Test with zero bytes from second array
-        result = ArrayConverter.concatenate(array1, array2, 0);
+        result = DataConverter.concatenate(array1, array2, 0);
         assertEquals(3, result.length, "Should have length 3");
         assertArrayEquals(
                 array1, result, "Should only use first array when second byte count is 0");
@@ -526,43 +523,43 @@ class ArrayConverterTest {
         // Test with null first array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(null, array2, 1),
+                () -> DataConverter.concatenate(null, array2, 1),
                 "First array null should throw IllegalArgumentException");
 
         // Test with null second array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(array1, null, 1),
+                () -> DataConverter.concatenate(array1, null, 1),
                 "Second array null should throw IllegalArgumentException");
 
         // Test with invalid number of bytes (negative)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(array1, array2, -1),
+                () -> DataConverter.concatenate(array1, array2, -1),
                 "Negative bytes should throw IllegalArgumentException");
 
         // Test with invalid number of bytes (greater than array2.length)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.concatenate(array1, array2, array2.length + 1),
+                () -> DataConverter.concatenate(array1, array2, array2.length + 1),
                 "Too many bytes should throw IllegalArgumentException");
     }
 
-    /** Test of makeArrayNonZero method, of class ArrayConverter. */
+    /** Test of makeArrayNonZero method, of class DataConverter. */
     @Test
     void testMakeArrayNonZero() {
         // Test with array containing zeros
         byte[] testArray = {0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00};
         byte[] expectedArray = {0x01, 0x01, 0x01, 0x02, 0x01, 0x03, 0x01};
 
-        ArrayConverter.makeArrayNonZero(testArray);
+        DataConverter.makeArrayNonZero(testArray);
         assertArrayEquals(expectedArray, testArray, "All zero bytes should be replaced with 0x01");
 
         // Test with array containing no zeros
         testArray = new byte[] {0x01, 0x02, 0x03, 0x04};
         byte[] originalArray = testArray.clone();
 
-        ArrayConverter.makeArrayNonZero(testArray);
+        DataConverter.makeArrayNonZero(testArray);
         assertArrayEquals(originalArray, testArray, "Array without zeros should remain unchanged");
 
         // Test with all zeros
@@ -572,51 +569,51 @@ class ArrayConverterTest {
             expectedArray[i] = 0x01;
         }
 
-        ArrayConverter.makeArrayNonZero(testArray);
+        DataConverter.makeArrayNonZero(testArray);
         assertArrayEquals(
                 expectedArray, testArray, "All-zero array should be completely replaced with 0x01");
 
         // Test with empty array
         testArray = new byte[0];
-        ArrayConverter.makeArrayNonZero(testArray);
+        DataConverter.makeArrayNonZero(testArray);
         assertEquals(0, testArray.length, "Empty array should remain empty");
 
         // Test with null array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.makeArrayNonZero(null),
+                () -> DataConverter.makeArrayNonZero(null),
                 "Null array should throw IllegalArgumentException");
     }
 
-    /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
+    /** Test of bigIntegerToByteArray method, of class DataConverter. */
     @Test
     void testBigIntegerToByteArray_3args() {
         // Test with expected length and remove sign byte
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
 
         // Test with expected length = 8 and remove sign byte = true
-        byte[] result = ArrayConverter.bigIntegerToByteArray(testValue, 8, true);
+        byte[] result = DataConverter.bigIntegerToByteArray(testValue, 8, true);
         assertEquals(8, result.length, "Should have length 8");
         // Only verify the length, not the exact content as the padding behavior seems different
         // than what we expected
 
         // Test with expected length = 4 and remove sign byte = true (truncated)
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(8, result.length, "Should have length 8 since BigInteger is larger");
 
         // Test with zero value
         testValue = BigInteger.ZERO;
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(4, result.length, "Zero should have expected length");
         assertArrayEquals(new byte[4], result, "Zero should be all zeros");
 
         // Test with zero expected length
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 0, true);
+        result = DataConverter.bigIntegerToByteArray(testValue, 0, true);
         assertEquals(0, result.length, "With expected length 0, should return empty array");
 
         // Test with negative value (should have sign byte)
         testValue = new BigInteger("-ABCDEF", 16);
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, false);
+        result = DataConverter.bigIntegerToByteArray(testValue, 4, false);
         assertEquals(4, result.length, "Should respect expected length");
 
         // Test with sign byte that should be preserved
@@ -624,26 +621,26 @@ class ArrayConverterTest {
         byte[] rawBytes = testValue.toByteArray(); // Should be: [00, 80, AB, CD, EF]
         assertTrue(rawBytes[0] == 0x00, "Should have sign byte");
 
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, false);
+        result = DataConverter.bigIntegerToByteArray(testValue, 4, false);
         assertEquals(8, result.length, "Should have padding to be multiple of expected length");
 
-        result = ArrayConverter.bigIntegerToByteArray(testValue, 4, true);
+        result = DataConverter.bigIntegerToByteArray(testValue, 4, true);
         assertEquals(4, result.length, "Should remove sign byte and match expected length");
 
         // Test with null value
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bigIntegerToByteArray(null, 4, true),
+                () -> DataConverter.bigIntegerToByteArray(null, 4, true),
                 "Null BigInteger should throw IllegalArgumentException");
     }
 
-    /** Test of bigIntegerToByteArray method, of class ArrayConverter. */
+    /** Test of bigIntegerToByteArray method, of class DataConverter. */
     @Test
     void testBigIntegerToByteArray_BigInteger() {
         // Test with simple positive value
         BigInteger testValue = new BigInteger("ABCDEF1234567890", 16);
-        byte[] expected = ArrayConverter.hexStringToByteArray("ABCDEF1234567890");
-        byte[] result = ArrayConverter.bigIntegerToByteArray(testValue);
+        byte[] expected = DataConverter.hexStringToByteArray("ABCDEF1234567890");
+        byte[] result = DataConverter.bigIntegerToByteArray(testValue);
         assertArrayEquals(expected, result, "Should convert simple BigInteger correctly");
 
         // Test with value that has high bit set (would have sign byte)
@@ -651,23 +648,23 @@ class ArrayConverterTest {
         byte[] rawBytes = testValue.toByteArray(); // Should be: [00, 80, AB, CD, EF]
         assertTrue(rawBytes[0] == 0x00, "Should have sign byte in raw conversion");
 
-        expected = ArrayConverter.hexStringToByteArray("80ABCDEF");
-        result = ArrayConverter.bigIntegerToByteArray(testValue);
+        expected = DataConverter.hexStringToByteArray("80ABCDEF");
+        result = DataConverter.bigIntegerToByteArray(testValue);
         assertArrayEquals(expected, result, "Should remove sign byte");
 
         // Test with zero
         testValue = BigInteger.ZERO;
-        result = ArrayConverter.bigIntegerToByteArray(testValue);
+        result = DataConverter.bigIntegerToByteArray(testValue);
         assertTrue(result.length == 0, "Zero should be represented as either an empty array");
 
         // Test with null value
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bigIntegerToByteArray(null),
+                () -> DataConverter.bigIntegerToByteArray(null),
                 "Null BigInteger should throw IllegalArgumentException");
     }
 
-    /** Test of convertListToArray method, of class ArrayConverter. */
+    /** Test of convertListToArray method, of class DataConverter. */
     @Test
     void testConvertListToArray() {
         List<BigInteger> testList = new ArrayList<>();
@@ -676,7 +673,7 @@ class ArrayConverterTest {
         testList.add(BigInteger.valueOf(3));
         testList.add(BigInteger.valueOf(Integer.MAX_VALUE));
 
-        BigInteger[] result = ArrayConverter.convertListToArray(testList);
+        BigInteger[] result = DataConverter.convertListToArray(testList);
 
         assertEquals(4, result.length, "Array length should match list size");
         assertEquals(BigInteger.valueOf(1), result[0], "First element should match");
@@ -687,14 +684,14 @@ class ArrayConverterTest {
 
         // Test with empty list
         testList = new ArrayList<>();
-        result = ArrayConverter.convertListToArray(testList);
+        result = DataConverter.convertListToArray(testList);
         assertEquals(0, result.length, "Empty list should convert to empty array");
 
         // Test with large values
         testList = new ArrayList<>();
         testList.add(new BigInteger("FFFFFFFFFFFFFFFF", 16));
         testList.add(new BigInteger("7FFFFFFFFFFFFFFF", 16));
-        result = ArrayConverter.convertListToArray(testList);
+        result = DataConverter.convertListToArray(testList);
         assertEquals(2, result.length, "Should handle large BigInteger values");
         assertEquals(
                 new BigInteger("FFFFFFFFFFFFFFFF", 16),
@@ -708,39 +705,39 @@ class ArrayConverterTest {
         // Test with null list
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.convertListToArray(null),
+                () -> DataConverter.convertListToArray(null),
                 "Null list should throw IllegalArgumentException");
     }
 
-    /** Test of hexStringToByteArray method, of class ArrayConverter. */
+    /** Test of hexStringToByteArray method, of class DataConverter. */
     @Test
     void testHexStringToByteArray() {
         String hex = "01";
         assertArrayEquals(
                 new byte[] {0x01},
-                ArrayConverter.hexStringToByteArray(hex),
+                DataConverter.hexStringToByteArray(hex),
                 "Testing simple one byte hex value");
         hex = "FF";
         assertArrayEquals(
                 new byte[] {(byte) 0xff},
-                ArrayConverter.hexStringToByteArray(hex),
+                DataConverter.hexStringToByteArray(hex),
                 "Testing one byte hex value > 0x7f");
         hex = "FFFFFF";
         assertArrayEquals(
                 new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff},
-                ArrayConverter.hexStringToByteArray(hex),
+                DataConverter.hexStringToByteArray(hex),
                 "Testing one byte hex value > 0x7f");
 
         // Test with null input (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.hexStringToByteArray(null),
+                () -> DataConverter.hexStringToByteArray(null),
                 "Should throw IllegalArgumentException for null input");
 
         // Test with odd length string (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.hexStringToByteArray("ABC"),
+                () -> DataConverter.hexStringToByteArray("ABC"),
                 "Should throw IllegalArgumentException for odd-length string");
     }
 
@@ -750,45 +747,45 @@ class ArrayConverterTest {
 
         assertArrayEquals(
                 new byte[0],
-                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 0),
+                DataConverter.bigIntegerToNullPaddedByteArray(test, 0),
                 "Check zero output size");
         assertArrayEquals(
                 new byte[] {(byte) 0xEC},
-                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 1),
+                DataConverter.bigIntegerToNullPaddedByteArray(test, 1),
                 "Check check output size smaller than input");
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray("0000000000000000000000001D42C86F7923DFEC"),
-                ArrayConverter.bigIntegerToNullPaddedByteArray(test, 20),
+                DataConverter.hexStringToByteArray("0000000000000000000000001D42C86F7923DFEC"),
+                DataConverter.bigIntegerToNullPaddedByteArray(test, 20),
                 "Check output size bigger than input size");
 
         // Test with null input (should throw IllegalArgumentException)
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bigIntegerToNullPaddedByteArray(null, 8),
+                () -> DataConverter.bigIntegerToNullPaddedByteArray(null, 8),
                 "Should throw IllegalArgumentException for null input");
     }
 
     @Test
     void testLongToUint48Bytes() {
         long testValue = 0x0000123456789ABCL;
-        byte[] expectedResult = ArrayConverter.hexStringToByteArray("123456789ABC");
+        byte[] expectedResult = DataConverter.hexStringToByteArray("123456789ABC");
 
         assertArrayEquals(
                 expectedResult,
-                ArrayConverter.longToUint48Bytes(testValue),
+                DataConverter.longToUint48Bytes(testValue),
                 "Assert correct output");
 
         testValue = 0x0000000000000001L;
-        expectedResult = ArrayConverter.hexStringToByteArray("000000000001");
+        expectedResult = DataConverter.hexStringToByteArray("000000000001");
 
         assertArrayEquals(
                 expectedResult,
-                ArrayConverter.longToUint48Bytes(testValue),
+                DataConverter.longToUint48Bytes(testValue),
                 "Assert correct output");
     }
 
     /**
-     * Test of bytesToHexString method, of class ArrayConverter. Differences in the overloaded
+     * Test of bytesToHexString method, of class DataConverter. Differences in the overloaded
      * methods should be visible in the other tests since the methods just pass the .getValue().
      */
     @Test
@@ -798,13 +795,13 @@ class ArrayConverterTest {
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x11, 0x22, 0x33, 0x44});
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
-        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(mba));
+        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(mba));
+        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -813,7 +810,7 @@ class ArrayConverterTest {
                             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10
                         });
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08 09 10", ArrayConverter.bytesToHexString(mba));
+        assertEquals("00 01 02 03 04 05 06 07 08 09 10", DataConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -825,7 +822,7 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(mba));
+                DataConverter.bytesToHexString(mba));
 
         toTest =
                 ModifiableVariableFactory.safelySetValue(
@@ -838,12 +835,12 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(mba));
+                DataConverter.bytesToHexString(mba));
     }
 
     /**
      * Test of bytesToHexString method with three parameters for ModifiableByteArray, of class
-     * ArrayConverter.
+     * DataConverter.
      */
     @Test
     void testBytesToHexString_ModifiableByteArray_3args() {
@@ -860,22 +857,22 @@ class ArrayConverterTest {
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, true, true));
+                DataConverter.bytesToHexString(mba, true, true));
 
         // Test with pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, true, false));
+                DataConverter.bytesToHexString(mba, true, false));
 
         // Test without pretty printing and initialNewLine=true (should be ignored)
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, false, true));
+                DataConverter.bytesToHexString(mba, false, true));
 
         // Test without pretty printing and initialNewLine=false
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, false, false));
+                DataConverter.bytesToHexString(mba, false, false));
 
         // Test with longer array
         toTest =
@@ -893,23 +890,23 @@ class ArrayConverterTest {
         // Test with pretty printing and initialNewLine=true for longer array
         String expected =
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07";
-        assertEquals(expected, ArrayConverter.bytesToHexString(mba, true, true));
+        assertEquals(expected, DataConverter.bytesToHexString(mba, true, true));
 
         // Test with pretty printing and initialNewLine=false for longer array
         expected =
                 "00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07";
-        assertEquals(expected, ArrayConverter.bytesToHexString(mba, true, false));
+        assertEquals(expected, DataConverter.bytesToHexString(mba, true, false));
 
         // Test with null ModifiableByteArray
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null, true, true),
+                () -> DataConverter.bytesToHexString((ModifiableByteArray) null, true, true),
                 "Null ModifiableByteArray should throw IllegalArgumentException");
     }
 
     /**
      * Test of bytesToHexString method with two parameters for ModifiableByteArray, of class
-     * ArrayConverter.
+     * DataConverter.
      */
     @Test
     void testBytesToHexString_ModifiableByteArray_boolean() {
@@ -920,14 +917,14 @@ class ArrayConverterTest {
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x11, 0x22, 0x33, 0x44});
         ModifiableByteArray mba = toTest; // Variable to help the compiler disambiguate
-        assertEquals("00 11 22 33 44", ArrayConverter.bytesToHexString(mba, false));
+        assertEquals("00 11 22 33 44", DataConverter.bytesToHexString(mba, false));
 
         // Test a medium array (9 bytes) with pretty printing disabled
         toTest =
                 ModifiableVariableFactory.safelySetValue(
                         toTest, new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
         mba = toTest;
-        assertEquals("00 01 02 03 04 05 06 07 08", ArrayConverter.bytesToHexString(mba, false));
+        assertEquals("00 01 02 03 04 05 06 07 08", DataConverter.bytesToHexString(mba, false));
 
         // Test a 16-byte array with pretty printing enabled
         toTest =
@@ -940,12 +937,12 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, true));
+                DataConverter.bytesToHexString(mba, true));
 
         // Test a 16-byte array with pretty printing disabled
         assertEquals(
                 "00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F",
-                ArrayConverter.bytesToHexString(mba, false));
+                DataConverter.bytesToHexString(mba, false));
 
         // Test a larger array (32 bytes) with pretty printing enabled
         toTest =
@@ -959,17 +956,17 @@ class ArrayConverterTest {
         mba = toTest;
         assertEquals(
                 "\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07\n00 01 02 03 04 05 06 07  00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(mba, true));
+                DataConverter.bytesToHexString(mba, true));
 
         // Test a larger array with pretty printing disabled
         assertEquals(
                 "00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07 00 01 02 03 04 05 06 07",
-                ArrayConverter.bytesToHexString(mba, false));
+                DataConverter.bytesToHexString(mba, false));
 
         // Test with null ModifiableByteArray
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString((ModifiableByteArray) null, false),
+                () -> DataConverter.bytesToHexString((ModifiableByteArray) null, false),
                 "Null ModifiableByteArray should throw IllegalArgumentException");
     }
 
@@ -981,42 +978,42 @@ class ArrayConverterTest {
         // Test for the single argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString(mba),
+                () -> DataConverter.bytesToHexString(mba),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
 
         // Test for the two argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString(mba, true),
+                () -> DataConverter.bytesToHexString(mba, true),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
 
         // Test for the three argument bytesToHexString
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.bytesToHexString(mba, true, true),
+                () -> DataConverter.bytesToHexString(mba, true, true),
                 "ModifiableByteArray with null value should throw IllegalArgumentException");
     }
 
-    /** Test of reverseByteOrder method, of class ArrayConverter. */
+    /** Test of reverseByteOrder method, of class DataConverter. */
     @Test
     void testReverseByteOrder() {
         byte[] array = {0x00, 0x01, 0x02, 0x03, 0x04};
 
         assertArrayEquals(
                 new byte[] {0x04, 0x03, 0x02, 0x01, 0x00},
-                ArrayConverter.reverseByteOrder(array),
+                DataConverter.reverseByteOrder(array),
                 "Testing byte order reversion");
 
         // Test with null array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.reverseByteOrder(null),
+                () -> DataConverter.reverseByteOrder(null),
                 "Null array should throw IllegalArgumentException");
 
         // Test with empty array
         assertArrayEquals(
                 new byte[0],
-                ArrayConverter.reverseByteOrder(new byte[0]),
+                DataConverter.reverseByteOrder(new byte[0]),
                 "Empty array should be reversed to empty array");
     }
 
@@ -1025,7 +1022,7 @@ class ArrayConverterTest {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             BigInteger b = new BigInteger(1024 + r.nextInt(1000), r);
-            byte[] bigIntegerToByteArray = ArrayConverter.bigIntegerToByteArray(b);
+            byte[] bigIntegerToByteArray = DataConverter.bigIntegerToByteArray(b);
             BigInteger c = new BigInteger(1, bigIntegerToByteArray);
             assertEquals(b, c);
         }
@@ -1034,7 +1031,7 @@ class ArrayConverterTest {
     @Test
     void testBigIntegerToByteArrayWithZero() {
         // Test with BigInteger.ZERO
-        byte[] result = ArrayConverter.bigIntegerToByteArray(BigInteger.ZERO);
+        byte[] result = DataConverter.bigIntegerToByteArray(BigInteger.ZERO);
         assertArrayEquals(new byte[0], result, "BigInteger.ZERO should convert to new byte[0]");
     }
 
@@ -1043,29 +1040,29 @@ class ArrayConverterTest {
         // Test with positive byte values (0-127)
         assertEquals(
                 0,
-                ArrayConverter.byteToUnsignedInt((byte) 0x00),
+                DataConverter.byteToUnsignedInt((byte) 0x00),
                 "0x00 should convert to unsigned int 0");
         assertEquals(
                 1,
-                ArrayConverter.byteToUnsignedInt((byte) 0x01),
+                DataConverter.byteToUnsignedInt((byte) 0x01),
                 "0x01 should convert to unsigned int 1");
         assertEquals(
                 127,
-                ArrayConverter.byteToUnsignedInt((byte) 0x7F),
+                DataConverter.byteToUnsignedInt((byte) 0x7F),
                 "0x7F should convert to unsigned int 127");
 
         // Test with negative byte values (which are unsigned 128-255)
         assertEquals(
                 128,
-                ArrayConverter.byteToUnsignedInt((byte) 0x80),
+                DataConverter.byteToUnsignedInt((byte) 0x80),
                 "0x80 should convert to unsigned int 128");
         assertEquals(
                 255,
-                ArrayConverter.byteToUnsignedInt((byte) 0xFF),
+                DataConverter.byteToUnsignedInt((byte) 0xFF),
                 "0xFF should convert to unsigned int 255");
         assertEquals(
                 200,
-                ArrayConverter.byteToUnsignedInt((byte) 0xC8),
+                DataConverter.byteToUnsignedInt((byte) 0xC8),
                 "0xC8 should convert to unsigned int 200");
     }
 
@@ -1078,7 +1075,7 @@ class ArrayConverterTest {
         long expected = 0x0123456789ABCDEFL;
         assertEquals(
                 expected,
-                ArrayConverter.uInt64BytesToLong(testBytes),
+                DataConverter.uInt64BytesToLong(testBytes),
                 "Should convert 8 bytes to correct long value");
 
         // Test with all zeros
@@ -1086,7 +1083,7 @@ class ArrayConverterTest {
         expected = 0L;
         assertEquals(
                 expected,
-                ArrayConverter.uInt64BytesToLong(testBytes),
+                DataConverter.uInt64BytesToLong(testBytes),
                 "All zeros should convert to 0L");
 
         // Test with all ones (FF)
@@ -1097,20 +1094,20 @@ class ArrayConverterTest {
         expected = -1L; // All bits set in a long
         assertEquals(
                 expected,
-                ArrayConverter.uInt64BytesToLong(testBytes),
+                DataConverter.uInt64BytesToLong(testBytes),
                 "All FFs should convert to -1L (all bits set)");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.uInt64BytesToLong(null),
+                () -> DataConverter.uInt64BytesToLong(null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with wrong length
         final byte[] wrongLengthArray = new byte[7]; // Not 8 bytes
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.uInt64BytesToLong(wrongLengthArray),
+                () -> DataConverter.uInt64BytesToLong(wrongLengthArray),
                 "Array != 8 bytes should throw IllegalArgumentException");
     }
 
@@ -1121,7 +1118,7 @@ class ArrayConverterTest {
         long expected = 0x89ABCDEFL;
         assertEquals(
                 expected,
-                ArrayConverter.uInt32BytesToLong(testBytes),
+                DataConverter.uInt32BytesToLong(testBytes),
                 "Should convert 4 bytes to correct long value");
 
         // Test with all zeros
@@ -1129,7 +1126,7 @@ class ArrayConverterTest {
         expected = 0L;
         assertEquals(
                 expected,
-                ArrayConverter.uInt32BytesToLong(testBytes),
+                DataConverter.uInt32BytesToLong(testBytes),
                 "All zeros should convert to 0L");
 
         // Test with all ones (FF)
@@ -1140,7 +1137,7 @@ class ArrayConverterTest {
         expected = 0xFFFFFFFFL; // 32 bits set
         assertEquals(
                 expected,
-                ArrayConverter.uInt32BytesToLong(testBytes),
+                DataConverter.uInt32BytesToLong(testBytes),
                 "All FFs should convert to 0xFFFFFFFFL");
 
         // Test with high bit set (would be negative in a 32-bit int)
@@ -1148,20 +1145,20 @@ class ArrayConverterTest {
         expected = 0x80000000L;
         assertEquals(
                 expected,
-                ArrayConverter.uInt32BytesToLong(testBytes),
+                DataConverter.uInt32BytesToLong(testBytes),
                 "High bit should be preserved as unsigned");
 
         // Test with null input
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.uInt32BytesToLong(null),
+                () -> DataConverter.uInt32BytesToLong(null),
                 "Null input should throw IllegalArgumentException");
 
         // Test with wrong length
         final byte[] wrongLengthArray = new byte[3]; // Not 4 bytes
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.uInt32BytesToLong(wrongLengthArray),
+                () -> DataConverter.uInt32BytesToLong(wrongLengthArray),
                 "Array != 4 bytes should throw IllegalArgumentException");
     }
 
@@ -1170,48 +1167,48 @@ class ArrayConverterTest {
         Random r = new Random(0);
         for (int i = 0; i < 10000; i++) {
             Integer b = r.nextInt();
-            byte[] intBytes = ArrayConverter.intToBytes(b, 4);
-            Integer c = ArrayConverter.bytesToInt(intBytes);
+            byte[] intBytes = DataConverter.intToBytes(b, 4);
+            Integer c = DataConverter.bytesToInt(intBytes);
             assertEquals(b, c);
         }
     }
 
-    /** Test of indexOf method, of class ArrayConverter. */
+    /** Test of indexOf method, of class DataConverter. */
     @Test
     void testIndexOf() {
-        byte[] outerArray = ArrayConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
-        byte[] innerArray1 = ArrayConverter.hexStringToByteArray("BBCCDD");
-        byte[] innerArray2 = ArrayConverter.hexStringToByteArray("BBCCDDEE");
-        byte[] innerArray3 = ArrayConverter.hexStringToByteArray("FF");
+        byte[] outerArray = DataConverter.hexStringToByteArray("AABBCCDDAABBCCDD");
+        byte[] innerArray1 = DataConverter.hexStringToByteArray("BBCCDD");
+        byte[] innerArray2 = DataConverter.hexStringToByteArray("BBCCDDEE");
+        byte[] innerArray3 = DataConverter.hexStringToByteArray("FF");
         byte[] emptyArray = new byte[0];
 
-        assertEquals(1, ArrayConverter.indexOf(outerArray, innerArray1));
-        assertNull(ArrayConverter.indexOf(outerArray, innerArray2));
-        assertNull(ArrayConverter.indexOf(outerArray, innerArray3));
+        assertEquals(1, DataConverter.indexOf(outerArray, innerArray1));
+        assertNull(DataConverter.indexOf(outerArray, innerArray2));
+        assertNull(DataConverter.indexOf(outerArray, innerArray3));
 
         // Test with null outer array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.indexOf(null, innerArray1),
+                () -> DataConverter.indexOf(null, innerArray1),
                 "Null outer array should throw IllegalArgumentException");
 
         // Test with null inner array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.indexOf(outerArray, null),
+                () -> DataConverter.indexOf(outerArray, null),
                 "Null inner array should throw IllegalArgumentException");
 
         // Test with empty inner array
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ArrayConverter.indexOf(outerArray, emptyArray),
+                () -> DataConverter.indexOf(outerArray, emptyArray),
                 "Empty inner array should throw IllegalArgumentException");
 
         // Test with inner array longer than outer array
         byte[] smallOuterArray = new byte[3];
         byte[] largeInnerArray = new byte[4];
         assertNull(
-                ArrayConverter.indexOf(smallOuterArray, largeInnerArray),
+                DataConverter.indexOf(smallOuterArray, largeInnerArray),
                 "Inner array should not be found when longer than outer array");
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/util/BadRandomTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/BadRandomTest.java
@@ -45,7 +45,7 @@ class BadRandomTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void testDeprecatedConstructorWithRandomAndSeed() {
+    static void testDeprecatedConstructorWithRandomAndSeed() {
         // Test that the deprecated constructor works
         // Use a fresh Random for each BadRandom to ensure we're testing functionality
         Random random1 = new Random(42);
@@ -72,7 +72,7 @@ class BadRandomTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void testDeprecatedConstructorWithRandomAndSpiAndProvider() {
+    static void testDeprecatedConstructorWithRandomAndSpiAndProvider() {
         // Test that the deprecated constructor works
         Random random1 = new Random(42);
         BadRandom badRandom = new BadRandom(random1, null, null);


### PR DESCRIPTION
## Summary
- Replaced all deprecated ArrayConverter usages with DataConverter
- Fixed static method warnings in BadRandomTest
- Updated all imports, class references, and JavaDoc comments

## Test plan
- [x] All tests pass successfully
- [x] Code compiles without deprecation warnings
- [x] Spotless formatting applied

This PR addresses issue #25 by replacing all deprecated ArrayConverter references with the new DataConverter class throughout the codebase.