### PR TITLE
Fix redundant type specification in ModifiableVariableHolderTest

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableHolderTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableHolderTest.java
@@ -125,7 +125,7 @@ class ModifiableVariableHolderTest {
     void testReset() {
         // Apply a modification to test reset
         VariableModification<Integer> modification =
-                new VariableModification<Integer>() {
+                new VariableModification<>() {
                     @Override
                     protected Integer modifyImplementationHook(Integer input) {
                         return input + 100;


### PR DESCRIPTION
## Summary
- Remove redundant `<Integer>` type argument from anonymous class instantiation at line 128
- The type can be inferred from the context using the diamond operator `<>`

## Test plan
- [x] Run `mvn test -Dtest=ModifiableVariableHolderTest` - all tests pass
- [x] Run `mvn spotless:apply` - no formatting changes needed
- [x] Verify the fix compiles without warnings