### PR TITLE
Make utility methods static in test classes

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/bool/ModifiableBooleanTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/bool/ModifiableBooleanTest.java
@@ -91,7 +91,8 @@ class ModifiableBooleanTest {
     }
 
     /** Helper method to set the protected assertEquals field using reflection */
-    private void setAssertEquals(ModifiableBoolean variable, Boolean value) throws Exception {
+    private static void setAssertEquals(ModifiableBoolean variable, Boolean value)
+            throws Exception {
         Field field = variable.getClass().getSuperclass().getDeclaredField("assertEquals");
         field.setAccessible(true);
         field.set(variable, value);

--- a/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableAnalyzerTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableAnalyzerTest.java
@@ -279,7 +279,7 @@ class ModifiableVariableAnalyzerTest {
     }
 
     /** Utility method to check if a list of Fields contains a field with the given name. */
-    private boolean containsFieldName(String name, List<Field> list) {
+    private static boolean containsFieldName(String name, List<Field> list) {
         for (Field f : list) {
             if (f.getName().equals(name)) {
                 return true;


### PR DESCRIPTION
## Summary
- Made `containsFieldName` method static in `ModifiableVariableAnalyzerTest`
- Made `setAssertEquals` method static in `ModifiableBooleanTest`

These utility methods don't access instance variables, so they should be static as per static code analysis recommendations.

## Changes
- `/src/test/java/de/rub/nds/modifiablevariable/util/ModifiableVariableAnalyzerTest.java:282` - Made `containsFieldName` method static
- `/src/test/java/de/rub/nds/modifiablevariable/bool/ModifiableBooleanTest.java:94` - Made `setAssertEquals` method static

## Test plan
✅ Ran all affected tests (`ModifiableVariableAnalyzerTest` and `ModifiableBooleanTest`) - all tests pass
✅ Verified code formatting with `mvn spotless:check` - no issues found
✅ Built project with `mvn clean package` - build successful