### PR TITLE
Fix unused code and imports in test files

### DIFF
--- a/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/ModifiableVariableTest.java
@@ -9,10 +9,7 @@ package de.rub.nds.modifiablevariable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import de.rub.nds.modifiablevariable.biginteger.*;
-import de.rub.nds.modifiablevariable.bytearray.*;
 import de.rub.nds.modifiablevariable.integer.*;
-import de.rub.nds.modifiablevariable.singlebyte.*;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerExplicitValueModificationTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,29 +156,20 @@ class BigIntegerExplicitValueModificationTest {
     /** Test constructor with null value */
     @Test
     void testConstructorWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
-            BigInteger nullValue = null;
-            new BigIntegerExplicitValueModification(nullValue);
-            fail("Constructor should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    new BigIntegerExplicitValueModification((BigInteger) null);
+                });
     }
 
     /** Test setExplicitValue with null value */
     @Test
     void testSetExplicitValueWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            b1.setExplicitValue(null);
-            // Should not reach here
-            fail("setExplicitValue should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    b1.setExplicitValue(null);
+                });
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerSubtractModificationTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,30 +166,20 @@ class BigIntegerSubtractModificationTest {
     /** Test constructor with null value */
     @Test
     void testConstructorWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
-            BigInteger nullValue = null;
-            BigIntegerSubtractModification mod = new BigIntegerSubtractModification(nullValue);
-            // Should not reach here
-            fail("Constructor should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    new BigIntegerSubtractModification((BigInteger) null);
+                });
     }
 
     /** Test setSubtrahend with null value */
     @Test
     void testSetSubtrahendWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            b1.setSubtrahend(null);
-            // Should not reach here
-            fail("setSubtrahend should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    b1.setSubtrahend(null);
+                });
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModificationTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/BigIntegerXorModificationTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -162,30 +162,20 @@ class BigIntegerXorModificationTest {
     /** Test constructor with null value */
     @Test
     void testConstructorWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            // Explicitly specify null as BigInteger to avoid ambiguity with copy constructor
-            BigInteger nullValue = null;
-            new BigIntegerXorModification(nullValue);
-            // Should not reach here
-            fail("Constructor should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    new BigIntegerXorModification((BigInteger) null);
+                });
     }
 
     /** Test setXor with null value */
     @Test
     void testSetXorWithNullValue() {
-        // Using try-catch because we expect an exception
-        try {
-            b1.setXor(null);
-            // Should not reach here
-            fail("setXor should throw NullPointerException");
-        } catch (NullPointerException e) {
-            // Expected exception
-            assertTrue(e.getMessage().contains("null"));
-        }
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    b1.setXor(null);
+                });
     }
 }


### PR DESCRIPTION
## Summary
- Removed unused wildcard imports from ModifiableVariableTest.java
- Refactored BigInteger test exception handling to use modern assertThrows pattern
- Eliminated static analyzer warnings about unused object allocations

## Changes Made
1. **ModifiableVariableTest.java**: Removed unused imports for `biginteger.*`, `bytearray.*`, and `singlebyte.*` packages
2. **BigInteger test files**: Converted try-catch exception testing pattern to JUnit 5's `assertThrows` method in:
   - BigIntegerXorModificationTest.java
   - BigIntegerSubtractModificationTest.java  
   - BigIntegerExplicitValueModificationTest.java

## Test plan
✅ All tests pass (`mvn test`)
✅ Code formatting applied (`mvn spotless:apply`)
✅ No compilation errors