### PR TITLE
Fix variable hiding issues in Builder methods and test classes

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayout.java
@@ -429,57 +429,56 @@ public final class ExtendedPatternLayout extends AbstractStringLayout {
         /**
          * Sets the conversion pattern to use for formatting log events.
          *
-         * @param pattern The pattern string
+         * @param patternValue The pattern string
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withPattern(String pattern) {
-            this.pattern = pattern;
+        public ExtendedPatternLayout.Builder withPattern(String patternValue) {
+            this.pattern = patternValue;
             return this;
         }
 
         /**
          * Sets the pattern selector for dynamic pattern selection based on log event properties.
          *
-         * @param patternSelector The pattern selector to use
+         * @param selector The pattern selector to use
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withPatternSelector(PatternSelector patternSelector) {
-            this.patternSelector = patternSelector;
+        public ExtendedPatternLayout.Builder withPatternSelector(PatternSelector selector) {
+            this.patternSelector = selector;
             return this;
         }
 
         /**
          * Sets the configuration to use for this layout.
          *
-         * @param configuration The configuration
+         * @param config The configuration
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withConfiguration(Configuration configuration) {
-            this.configuration = configuration;
+        public ExtendedPatternLayout.Builder withConfiguration(Configuration config) {
+            this.configuration = config;
             return this;
         }
 
         /**
          * Sets the regex replacement to apply to the formatted output.
          *
-         * @param regexReplacement The regex replacement
+         * @param replacement The regex replacement
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withRegexReplacement(
-                RegexReplacement regexReplacement) {
-            this.regexReplacement = regexReplacement;
+        public ExtendedPatternLayout.Builder withRegexReplacement(RegexReplacement replacement) {
+            this.regexReplacement = replacement;
             return this;
         }
 
         /**
          * Sets the character set to use for encoding the output.
          *
-         * @param charset The character set
+         * @param charsetValue The character set
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withCharset(Charset charset) {
-            if (charset != null) {
-                this.charset = charset;
+        public ExtendedPatternLayout.Builder withCharset(Charset charsetValue) {
+            if (charsetValue != null) {
+                this.charset = charsetValue;
             }
 
             return this;
@@ -488,56 +487,55 @@ public final class ExtendedPatternLayout extends AbstractStringLayout {
         /**
          * Sets whether to always include exception information in the output.
          *
-         * @param alwaysWriteExceptions Whether to always write exceptions
+         * @param writeExceptions Whether to always write exceptions
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withAlwaysWriteExceptions(
-                boolean alwaysWriteExceptions) {
-            this.alwaysWriteExceptions = alwaysWriteExceptions;
+        public ExtendedPatternLayout.Builder withAlwaysWriteExceptions(boolean writeExceptions) {
+            this.alwaysWriteExceptions = writeExceptions;
             return this;
         }
 
         /**
          * Sets whether to disable ANSI escape codes in the output.
          *
-         * @param disableAnsi Whether to disable ANSI escape codes
+         * @param disable Whether to disable ANSI escape codes
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withDisableAnsi(boolean disableAnsi) {
-            this.disableAnsi = disableAnsi;
+        public ExtendedPatternLayout.Builder withDisableAnsi(boolean disable) {
+            this.disableAnsi = disable;
             return this;
         }
 
         /**
          * Sets whether to disable ANSI escapes when output is not to a console.
          *
-         * @param noConsoleNoAnsi Whether to disable ANSI when not writing to console
+         * @param noAnsi Whether to disable ANSI when not writing to console
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withNoConsoleNoAnsi(boolean noConsoleNoAnsi) {
-            this.noConsoleNoAnsi = noConsoleNoAnsi;
+        public ExtendedPatternLayout.Builder withNoConsoleNoAnsi(boolean noAnsi) {
+            this.noConsoleNoAnsi = noAnsi;
             return this;
         }
 
         /**
          * Sets the pattern to use for the header.
          *
-         * @param header The header pattern
+         * @param headerValue The header pattern
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withHeader(String header) {
-            this.header = header;
+        public ExtendedPatternLayout.Builder withHeader(String headerValue) {
+            this.header = headerValue;
             return this;
         }
 
         /**
          * Sets the pattern to use for the footer.
          *
-         * @param footer The footer pattern
+         * @param footerValue The footer pattern
          * @return This builder instance
          */
-        public ExtendedPatternLayout.Builder withFooter(String footer) {
-            this.footer = footer;
+        public ExtendedPatternLayout.Builder withFooter(String footerValue) {
+            this.footer = footerValue;
             return this;
         }
 

--- a/src/test/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigIntegerTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/biginteger/ModifiableBigIntegerTest.java
@@ -314,52 +314,52 @@ class ModifiableBigIntegerTest {
     @Test
     void testEqualsWithDifferentModificationTypesSameResult() {
         // Different modification types resulting in the same final value
-        ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(10));
-        ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger1 = new ModifiableBigInteger(BigInteger.valueOf(10));
+        ModifiableBigInteger testInteger2 = new ModifiableBigInteger(BigInteger.valueOf(5));
         ModifiableBigInteger integer3 = new ModifiableBigInteger(BigInteger.valueOf(2));
 
         // 10 + 10 = 20
-        integer1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(10)));
+        testInteger1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(10)));
         // 5 * 4 = 20
-        integer2.setModifications(new BigIntegerMultiplyModification(BigInteger.valueOf(4)));
+        testInteger2.setModifications(new BigIntegerMultiplyModification(BigInteger.valueOf(4)));
         // 2 << 3 = 16, then + 4 = 20
         integer3.setModifications(new BigIntegerShiftLeftModification(3));
         integer3.addModification(new BigIntegerAddModification(BigInteger.valueOf(4)));
 
         // All should be equal since they result in the same value (20)
-        assertEquals(integer1.getValue(), integer2.getValue());
-        assertEquals(integer2.getValue(), integer3.getValue());
-        assertEquals(integer1, integer2);
-        assertEquals(integer2, integer3);
-        assertEquals(integer1, integer3);
+        assertEquals(testInteger1.getValue(), testInteger2.getValue());
+        assertEquals(testInteger2.getValue(), integer3.getValue());
+        assertEquals(testInteger1, testInteger2);
+        assertEquals(testInteger2, integer3);
+        assertEquals(testInteger1, integer3);
     }
 
     /** Test equals method with chained modifications */
     @Test
     void testEqualsWithChainedModifications() {
         // Two objects with the same chain of modifications
-        ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(5));
-        ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger1 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger2 = new ModifiableBigInteger(BigInteger.valueOf(5));
 
         // Apply a sequence of modifications to both integers
-        integer1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
-        integer1.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
-        integer1.addModification(new BigIntegerXorModification(BigInteger.valueOf(3)));
+        testInteger1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
+        testInteger1.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
+        testInteger1.addModification(new BigIntegerXorModification(BigInteger.valueOf(3)));
 
-        integer2.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
-        integer2.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
-        integer2.addModification(new BigIntegerXorModification(BigInteger.valueOf(3)));
+        testInteger2.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
+        testInteger2.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
+        testInteger2.addModification(new BigIntegerXorModification(BigInteger.valueOf(3)));
 
         // Should be equal
-        assertEquals(integer1.getValue(), integer2.getValue());
-        assertEquals(integer1, integer2);
+        assertEquals(testInteger1.getValue(), testInteger2.getValue());
+        assertEquals(testInteger1, testInteger2);
 
         // Modify one by adding another modification
-        integer1.addModification(new BigIntegerAddModification(BigInteger.valueOf(1)));
+        testInteger1.addModification(new BigIntegerAddModification(BigInteger.valueOf(1)));
 
         // No longer equal
-        assertNotEquals(integer1.getValue(), integer2.getValue());
-        assertNotEquals(integer1, integer2);
+        assertNotEquals(testInteger1.getValue(), testInteger2.getValue());
+        assertNotEquals(testInteger1, testInteger2);
     }
 
     /** Test equals method with modified null and non-null original values */
@@ -476,26 +476,26 @@ class ModifiableBigIntegerTest {
     @Test
     void testHashCodeWithChainedModifications() {
         // Same chain of modifications should produce same hash code
-        ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(5));
-        ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger1 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger2 = new ModifiableBigInteger(BigInteger.valueOf(5));
 
         // Create identical modification chains
-        integer1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
-        integer1.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
+        testInteger1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
+        testInteger1.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
 
-        integer2.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
-        integer2.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
+        testInteger2.setModifications(new BigIntegerAddModification(BigInteger.valueOf(5)));
+        testInteger2.addModification(new BigIntegerMultiplyModification(BigInteger.valueOf(2)));
 
         // Hash codes should be equal
-        assertEquals(integer1.getValue(), integer2.getValue());
-        assertEquals(integer1.hashCode(), integer2.hashCode());
+        assertEquals(testInteger1.getValue(), testInteger2.getValue());
+        assertEquals(testInteger1.hashCode(), testInteger2.hashCode());
 
         // Different modifications with same result should have same hash code
         ModifiableBigInteger integer3 = new ModifiableBigInteger(BigInteger.valueOf(5));
-        integer3.setModifications(new BigIntegerExplicitValueModification(integer1.getValue()));
+        integer3.setModifications(new BigIntegerExplicitValueModification(testInteger1.getValue()));
 
-        assertEquals(integer1.getValue(), integer3.getValue());
-        assertEquals(integer1.hashCode(), integer3.hashCode());
+        assertEquals(testInteger1.getValue(), integer3.getValue());
+        assertEquals(testInteger1.hashCode(), integer3.hashCode());
     }
 
     /** Test hashCode consistency with equals method */
@@ -504,26 +504,26 @@ class ModifiableBigIntegerTest {
         // Objects that are equal must have the same hash code
 
         // Different original values, same final result through different means
-        ModifiableBigInteger integer1 = new ModifiableBigInteger(BigInteger.valueOf(10));
-        ModifiableBigInteger integer2 = new ModifiableBigInteger(BigInteger.valueOf(5));
+        ModifiableBigInteger testInteger1 = new ModifiableBigInteger(BigInteger.valueOf(10));
+        ModifiableBigInteger testInteger2 = new ModifiableBigInteger(BigInteger.valueOf(5));
         ModifiableBigInteger integer3 = new ModifiableBigInteger(BigInteger.valueOf(2));
 
         // 10 + 10 = 20
-        integer1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(10)));
+        testInteger1.setModifications(new BigIntegerAddModification(BigInteger.valueOf(10)));
         // 5 * 4 = 20
-        integer2.setModifications(new BigIntegerMultiplyModification(BigInteger.valueOf(4)));
+        testInteger2.setModifications(new BigIntegerMultiplyModification(BigInteger.valueOf(4)));
         // 2 << 3 = 16, then + 4 = 20
         integer3.setModifications(new BigIntegerShiftLeftModification(3));
         integer3.addModification(new BigIntegerAddModification(BigInteger.valueOf(4)));
 
         // All should have the same hash code since they're equal
-        assertEquals(integer1, integer2);
-        assertEquals(integer1.hashCode(), integer2.hashCode());
+        assertEquals(testInteger1, testInteger2);
+        assertEquals(testInteger1.hashCode(), testInteger2.hashCode());
 
-        assertEquals(integer2, integer3);
-        assertEquals(integer2.hashCode(), integer3.hashCode());
+        assertEquals(testInteger2, integer3);
+        assertEquals(testInteger2.hashCode(), integer3.hashCode());
 
-        assertEquals(integer1, integer3);
-        assertEquals(integer1.hashCode(), integer3.hashCode());
+        assertEquals(testInteger1, integer3);
+        assertEquals(testInteger1.hashCode(), integer3.hashCode());
     }
 }

--- a/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
+++ b/src/test/java/de/rub/nds/modifiablevariable/logging/ExtendedPatternLayoutTest.java
@@ -389,12 +389,12 @@ class ExtendedPatternLayoutTest {
         String pattern = "%m%n";
         Configuration config = new DefaultConfiguration();
 
-        ExtendedPatternLayout layout =
+        ExtendedPatternLayout testLayout =
                 ExtendedPatternLayout.createLayout(
                         pattern, null, config, null, CHARSET, true, false, null, null);
 
-        assertNotNull(layout);
-        assertEquals(pattern, layout.getConversionPattern());
+        assertNotNull(testLayout);
+        assertEquals(pattern, testLayout.getConversionPattern());
     }
 
     @Test
@@ -405,7 +405,7 @@ class ExtendedPatternLayoutTest {
         String header = "HEADER";
         String footer = "FOOTER";
 
-        ExtendedPatternLayout layout =
+        ExtendedPatternLayout testLayout =
                 ExtendedPatternLayout.newBuilder()
                         .withPattern(PATTERN)
                         .withPatternSelector(patternSelector)
@@ -419,8 +419,8 @@ class ExtendedPatternLayoutTest {
                         .withFooter(footer)
                         .build();
 
-        assertNotNull(layout);
-        assertEquals(PATTERN, layout.getConversionPattern());
+        assertNotNull(testLayout);
+        assertEquals(PATTERN, testLayout.getConversionPattern());
     }
 
     @Test
@@ -457,14 +457,14 @@ class ExtendedPatternLayoutTest {
     @Test
     void testBuilderWithNullCharset() {
         // Test the withCharset method with null charset (should use default)
-        ExtendedPatternLayout layout =
+        ExtendedPatternLayout testLayout =
                 ExtendedPatternLayout.newBuilder().withPattern(PATTERN).withCharset(null).build();
 
-        assertNotNull(layout);
+        assertNotNull(testLayout);
         // Verify it works correctly
         String message = "Test message";
         LogEvent event = createLogEvent(new SimpleMessage(message));
-        String result = layout.toSerializable(event);
+        String result = testLayout.toSerializable(event);
         assertEquals(message + System.lineSeparator(), result);
     }
 


### PR DESCRIPTION
## Summary
- Fixed 32 instances of variable hiding identified by static analysis
- Changed parameter names in ExtendedPatternLayout.Builder methods to avoid shadowing instance fields
- Updated local variable names in test classes to prevent hiding of test fixture fields

## Changes Made

### ExtendedPatternLayout.java
- Changed parameter names in all Builder setter methods:
  - `pattern` → `patternValue`
  - `patternSelector` → `selector`
  - `configuration` → `config`
  - `regexReplacement` → `replacement`
  - `charset` → `charsetValue`
  - `alwaysWriteExceptions` → `writeExceptions`
  - `disableAnsi` → `disable`
  - `noConsoleNoAnsi` → `noAnsi`
  - `header` → `headerValue`
  - `footer` → `footerValue`
- Updated all corresponding Javadoc @param annotations

### ExtendedPatternLayoutTest.java
- Renamed local variable `layout` to `testLayout` in 3 test methods to avoid hiding the instance field

### ModifiableBigIntegerTest.java
- Renamed local variables `integer1` and `integer2` to `testInteger1` and `testInteger2` in 4 test methods to avoid hiding instance fields

## Test Plan
- [x] All existing tests pass
- [x] Code compiles without warnings
- [x] Spotless formatting applied successfully