### PR TITLE
fix: Update javadoc comments to reference DataConverter

### DIFF
--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayAppendValueModification.java
@@ -82,8 +82,8 @@ public class ByteArrayAppendValueModification extends VariableModification<byte[
      * Modifies the input by appending bytes to the end of the array.
      *
      * <p>This method concatenates the bytes to append to the end of the input byte array using the
-     * ArrayConverter's concatenate method. A new byte array is created with the original input
-     * bytes followed by the bytes to append.
+     * DataConverter's concatenate method. A new byte array is created with the original input bytes
+     * followed by the bytes to append.
      *
      * <p>Note that this operation creates a new array that is longer than the original input by the
      * length of the bytes to append. The original input remains unchanged.

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayDuplicateModification.java
@@ -59,7 +59,7 @@ public class ByteArrayDuplicateModification extends VariableModification<byte[]>
      * copy of itself, effectively doubling the length of the array. The operation preserves the
      * original array's contents and ordering, simply repeating it.
      *
-     * <p>The implementation uses the ArrayConverter's concatenate method for efficient array
+     * <p>The implementation uses the DataConverter's concatenate method for efficient array
      * manipulation and guarantees that the original array is not modified, maintaining
      * immutability.
      *

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayInsertValueModification.java
@@ -97,7 +97,7 @@ public class ByteArrayInsertValueModification extends VariableModification<byte[
      *   <li>If the position exceeds the array length, it's adjusted using modulo arithmetic
      * </ul>
      *
-     * <p>The implementation uses ArrayConverter for efficient concatenation operations, ensuring
+     * <p>The implementation uses DataConverter for efficient concatenation operations, ensuring
      * optimal performance even with large arrays.
      *
      * @param input The original byte array

--- a/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bytearray/ByteArrayPrependValueModification.java
@@ -83,7 +83,7 @@ public class ByteArrayPrependValueModification extends VariableModification<byte
      * Modifies the input by prepending bytes to the beginning of the array.
      *
      * <p>This method concatenates the bytes to prepend with the input byte array using the
-     * ArrayConverter's concatenate method. A new byte array is created with the bytes to prepend at
+     * DataConverter's concatenate method. A new byte array is created with the bytes to prepend at
      * the beginning followed by the original input bytes.
      *
      * <p>Note that this operation creates a new array that is longer than the original input by the


### PR DESCRIPTION
## Summary
- Updates javadoc comments to reference `DataConverter` instead of the deprecated `ArrayConverter` class
- Fixes outdated documentation in byte array modification classes

## Details
While investigating the deprecation warnings mentioned in the task, I found that all actual code references to `ArrayConverter` have already been migrated to use `DataConverter`. However, the javadoc comments in several files still referenced the old `ArrayConverter` class.

This PR updates the following javadoc comments:
- `ByteArrayAppendValueModification`: Updated comment about concatenate method
- `ByteArrayDuplicateModification`: Updated comment about concatenate method
- `ByteArrayInsertValueModification`: Updated comment about concatenation operations
- `ByteArrayPrependValueModification`: Updated comment about concatenate method

## Test plan
- [x] Code compiles successfully with `mvn clean compile`
- [x] All tests pass with `mvn test`
- [x] Spotless formatting applied with `mvn spotless:apply`
- [x] No functional changes - only documentation updates