### PR TITLE
Fix SpotBugs NP_BOOLEAN_RETURN_NULL warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.8.3</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- scope: test -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanExplicitValueModification.java
@@ -8,6 +8,7 @@
 package de.rub.nds.modifiablevariable.bool;
 
 import de.rub.nds.modifiablevariable.VariableModification;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -76,6 +77,9 @@ public class BooleanExplicitValueModification extends VariableModification<Boole
      * @return The explicit value, or null if input was null
      */
     @Override
+    @SuppressFBWarnings(
+            value = "NP_BOOLEAN_RETURN_NULL",
+            justification = "Null safety is preserved intentionally in the modification framework")
     protected Boolean modifyImplementationHook(Boolean input) {
         if (input == null) {
             return null;

--- a/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
+++ b/src/main/java/de/rub/nds/modifiablevariable/bool/BooleanToggleModification.java
@@ -8,6 +8,7 @@
 package de.rub.nds.modifiablevariable.bool;
 
 import de.rub.nds.modifiablevariable.VariableModification;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -59,6 +60,9 @@ public class BooleanToggleModification extends VariableModification<Boolean> {
      * @return The inverted Boolean value, or null if the input is null
      */
     @Override
+    @SuppressFBWarnings(
+            value = "NP_BOOLEAN_RETURN_NULL",
+            justification = "Null safety is preserved intentionally in the modification framework")
     protected Boolean modifyImplementationHook(Boolean input) {
         if (input == null) {
             return null;


### PR DESCRIPTION
## Summary
- Fixed SpotBugs warnings about methods with Boolean return type returning explicit null
- Added SpotBugs annotations dependency to suppress these warnings
- Applied suppressions to BooleanExplicitValueModification and BooleanToggleModification

## Details
The SpotBugs tool was reporting NP_BOOLEAN_RETURN_NULL warnings for the `modifyImplementationHook` methods in both `BooleanExplicitValueModification` and `BooleanToggleModification` classes. These methods return null when the input is null, which is intentional behavior to preserve null-safety throughout the modification framework.

The fix adds the SpotBugs annotations dependency and uses `@SuppressFBWarnings` to suppress these specific warnings with appropriate justification.

## Test plan
- [x] Verified that existing tests pass (they already test null handling)
- [x] Ran SpotBugs to confirm the warnings are resolved
- [x] Applied spotless formatting